### PR TITLE
Better slack message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0
+- Add all additional props to the top level `<Message/>` component
+- Remove `token` / `channel` prop since they are out of scope for the component
+
 ### 0.0.4
 - Fix issue where `<Actions/>` block would have incorrect type
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install the library with `npm i slackblock`
 const text = <Text plainText>Hello</Text>;
 
 const message = render(
-  <Message channel='someChannelId' token='Your token'>
+  <Message>
     <Section text={text}>
       <Text>Some *message* for _Slack_.</Text>
     </Section>
@@ -28,7 +28,6 @@ const message = render(
 console.log(message);
 /*
   {
-    "channel": "someChannelId",
     "blocks": [
       {
         "type": "section",
@@ -49,7 +48,7 @@ console.log(message);
 ```
 
 ## Things to note
-- The outputted message can be passed directly to the slack API for sending messages!
+- The outputted message only needs to have your `token` and desired `channel_id` added, and it will be ready to send to the slack API!
 - There is current _very little to no_ input validation. Non-recognized blocks will be ignored, but Slack will be the ultimate decider if your message is valid. Validation is on the roadmap.
 - There is currently almost no documentation. This will be resolved, but in general...
   - If a Slack message wants a property in format `foo_bar`, you will add it as a `fooBar` property in your message(ex: `<Element fooBar='blah'/>`)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install the library with `npm i slackblock`
 const text = <Text plainText>Hello</Text>;
 
 const message = render(
-  <Message channel='someChannelId'>
+  <Message channel='someChannelId' token='Your token'>
     <Section text={text}>
       <Text>Some *message* for _Slack_.</Text>
     </Section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slackblock",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackblock",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "React-based Slack message renderer",
   "main": "index.js",
   "scripts": {

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
-import {Block, Element} from '../constants/types'; 
+import {Element} from '../constants/types'; 
 
 type Props = {
   children: string | Element | Element[];
-  channel?: string;
-  replyTo?: string;
+  token: string;
+  channel: string;
+  text?: string;
+  asUser?: boolean;
+  iconEmoji?: string;
+  iconUrl?: string;
   markdown?: boolean;
-  blocks?: Block[];
+  parse?: 'full' | 'none';
+  replyBroadcast?: boolean;
+  replyTo?: string;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
+  username?: string;
 };
 
 export default class Message extends React.Component<Props> {}

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -3,8 +3,6 @@ import {Element} from '../constants/types';
 
 type Props = {
   children: string | Element | Element[];
-  token: string;
-  channel: string;
   text?: string;
   asUser?: boolean;
   iconEmoji?: string;

--- a/src/constants/types.d.ts
+++ b/src/constants/types.d.ts
@@ -60,13 +60,26 @@ export type SerializedInputBlockElement =
 export type BlockElement = InteractiveBlockElement & StandardBlockElement & InputBlockElement;
 export type SerializedBlockElement = TextType | ImageType | ConfirmationType;
 
-export type SlackMessage = {
-  channel?: string;
+export type PartialSlackMessage = {
   text?: string;
+  as_user?: boolean;
   blocks?: Block[];
-  thread_ts?: string;
+  icon_emoji?: string;
+  icon_url?: string;
+  link_names?: boolean;
   mrkdwn?: boolean;
+  parse?: 'full' | 'none';
+  reply_broadcast?: boolean;
+  thread_ts?: string;
+  unfurl_links?: boolean;
+  unfurl_media?: boolean;
+  username?: string;
 };
+
+export type SlackMessage = {
+  token: string;
+  channel: string;
+} & PartialSlackMessage;
 
 type AnyFunction = () => any;
 

--- a/src/constants/types.d.ts
+++ b/src/constants/types.d.ts
@@ -60,7 +60,7 @@ export type SerializedInputBlockElement =
 export type BlockElement = InteractiveBlockElement & StandardBlockElement & InputBlockElement;
 export type SerializedBlockElement = TextType | ImageType | ConfirmationType;
 
-export type PartialSlackMessage = {
+export type SlackMessage = {
   text?: string;
   as_user?: boolean;
   blocks?: Block[];
@@ -75,11 +75,6 @@ export type PartialSlackMessage = {
   unfurl_media?: boolean;
   username?: string;
 };
-
-export type SlackMessage = {
-  token: string;
-  channel: string;
-} & PartialSlackMessage;
 
 type AnyFunction = () => any;
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,8 +1,8 @@
-import {PartialSlackMessage, Child, Block} from '../constants/types';
+import {Child, Block, SlackMessage} from '../constants/types';
 import transformers from '../transformers';
 import getType from '../utils/get-type';
 
-export default (children: Child): PartialSlackMessage => {
+export default (children: Child): SlackMessage => {
   if (typeof children === 'string') {
     return {text: children};
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,8 +1,8 @@
-import {SlackMessage, Child, Block} from '../constants/types';
+import {PartialSlackMessage, Child, Block} from '../constants/types';
 import transformers from '../transformers';
 import getType from '../utils/get-type';
 
-export default (children: Child): SlackMessage => {
+export default (children: Child): PartialSlackMessage => {
   if (typeof children === 'string') {
     return {text: children};
   }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -14,13 +14,7 @@ const render = (element: Element): SlackMessage => {
     throw new Error('Cannot render a Message with no children.');
   }
 
-  const result = parser(props.children);
-
-  const json = {
-    token: props.token,
-    channel: props.channel,
-    ...result
-  };
+  const json = {...parser(props.children)};
 
   if (props.replyTo) {
     json.thread_ts = props.replyTo;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -17,7 +17,8 @@ const render = (element: Element): SlackMessage => {
   const result = parser(props.children);
 
   const json = {
-    channel: props.channel || null,
+    token: props.token,
+    channel: props.channel,
     ...result
   };
 
@@ -27,6 +28,40 @@ const render = (element: Element): SlackMessage => {
 
   if (typeof props.markdown !== 'undefined') {
     json.mrkdwn = props.markdown;
+  }
+
+  json.text = props.text || '';
+
+  if (props.iconEmoji) {
+    json.icon_emoji = props.iconEmoji;
+  }
+
+  if (props.iconUrl) {
+    json.icon_url = props.iconUrl;
+  }
+
+  if (props.parse) {
+    json.parse = props.parse;
+  }
+
+  if (props.username) {
+    json.username = props.username;
+  }
+
+  if (props.asUser) {
+    json.as_user = props.asUser;
+  }
+
+  if (props.replyBroadcast) {
+    json.reply_broadcast = props.replyBroadcast;
+  }
+
+  if (props.unfurlLinks) {
+    json.unfurl_links = props.unfurlLinks;
+  }
+
+  if (typeof props.unfurlMedia !== 'undefined') {
+    json.unfurl_media = props.unfurlMedia;
   }
 
   return json;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -5,7 +5,7 @@ import render from '../src';
 import Message from '../src/components/message';
 
 test('can accept React component without erroring', t => {
-  const fn = () => render(<Message>child</Message>);
+  const fn = () => render(<Message token="t" channel="t">child</Message>);
 
   t.notThrows(fn);
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -5,7 +5,7 @@ import render from '../src';
 import Message from '../src/components/message';
 
 test('can accept React component without erroring', t => {
-  const fn = () => render(<Message token="t" channel="t">child</Message>);
+  const fn = () => render(<Message>child</Message>);
 
   t.notThrows(fn);
 });

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -11,7 +11,7 @@ const render = proxyquire('../../src/renderer', {
 
 test('it passes a list of children to the parser', t => {
   const content = 'block-content';
-  render(<Message token="t" channel="c">{content}</Message>);
+  render(<Message>{content}</Message>);
 
   t.true(parser.calledWith(content));
 });
@@ -29,32 +29,10 @@ test('it throws an error if no children are passed', t => {
   t.throws(fn);
 });
 
-test('it accepts channel as a prop and renders it', t => {
-  const channel = 'abcde12345';
-  const result = render(<Message token="t" channel={channel}>Foo</Message>);
-
-  t.is(result.channel, channel);
-});
-
-test('it accepts a replyTo prop and renders it', t => {
-  const thread_ts = '12345.56';
-  const result = render(<Message token="t" channel="c" replyTo={thread_ts}>Foo</Message>);
-
-  t.is(result.thread_ts, thread_ts);
-});
-
-test('it accepts a markdown prop and renders it', t => {
-  const result = render(<Message token="t" channel="c" markdown={false}>Foo</Message>);
-
-  t.is(result.mrkdwn, false);
-});
-
 test('can render all props', t => {
   const content = 'content-of-block';
   const res = render(
     <Message
-      token="token"
-      channel="channel"
       text="text"
       iconEmoji=":icon_emoji:"
       iconUrl="iconUrl"
@@ -72,8 +50,6 @@ test('can render all props', t => {
   );
 
   t.deepEqual(res, {
-    token: 'token',
-    channel: 'channel',
     text: 'text',
     icon_emoji: ':icon_emoji:',
     icon_url: 'iconUrl',
@@ -91,7 +67,7 @@ test('can render all props', t => {
 });
 
 test('if no text prop is passed, uses a blank string', t => {
-  const res = render(<Message token="t" channel="c">Hello</Message>);
+  const res = render(<Message>Hello</Message>);
 
   t.is(res.text, '');
 });

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -11,7 +11,7 @@ const render = proxyquire('../../src/renderer', {
 
 test('it passes a list of children to the parser', t => {
   const content = 'block-content';
-  render(<Message>{content}</Message>);
+  render(<Message token="t" channel="c">{content}</Message>);
 
   t.true(parser.calledWith(content));
 });
@@ -31,20 +31,67 @@ test('it throws an error if no children are passed', t => {
 
 test('it accepts channel as a prop and renders it', t => {
   const channel = 'abcde12345';
-  const result = render(<Message channel={channel}>Foo</Message>);
+  const result = render(<Message token="t" channel={channel}>Foo</Message>);
 
   t.is(result.channel, channel);
 });
 
 test('it accepts a replyTo prop and renders it', t => {
   const thread_ts = '12345.56';
-  const result = render(<Message replyTo={thread_ts}>Foo</Message>);
+  const result = render(<Message token="t" channel="c" replyTo={thread_ts}>Foo</Message>);
 
   t.is(result.thread_ts, thread_ts);
 });
 
 test('it accepts a markdown prop and renders it', t => {
-  const result = render(<Message markdown={false}>Foo</Message>);
+  const result = render(<Message token="t" channel="c" markdown={false}>Foo</Message>);
 
   t.is(result.mrkdwn, false);
+});
+
+test('can render all props', t => {
+  const content = 'content-of-block';
+  const res = render(
+    <Message
+      token="token"
+      channel="channel"
+      text="text"
+      iconEmoji=":icon_emoji:"
+      iconUrl="iconUrl"
+      markdown={false}
+      parse="none"
+      username="username"
+      replyTo="replyTo"
+      asUser
+      replyBroadcast
+      unfurlLinks
+      unfurlMedia
+    >
+      {content}
+    </Message>
+  );
+
+  t.deepEqual(res, {
+    token: 'token',
+    channel: 'channel',
+    text: 'text',
+    icon_emoji: ':icon_emoji:',
+    icon_url: 'iconUrl',
+    mrkdwn: false,
+    parse: 'none',
+    username: 'username',
+    thread_ts: 'replyTo',
+    as_user: true,
+    reply_broadcast: true,
+    unfurl_links: true,
+    unfurl_media: true
+  });
+
+  t.true(parser.calledWith(content));
+});
+
+test('if no text prop is passed, uses a blank string', t => {
+  const res = render(<Message token="t" channel="c">Hello</Message>);
+
+  t.is(res.text, '');
 });


### PR DESCRIPTION
- Add all additional props to the top level `<Message/>` component
- Remove `token` / `channel` prop since they are out of scope for the component