### PR TITLE
Allow null and arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm-run-all test:*",
     "test:tsc": "tsc -p ./src -p ./test --noEmit",
-    "test:lint": "xo",
+    "test:lint": "xo --fix",
     "test:unit": "ava",
     "build": "npm-run-all build:*",
     "build:package": "tsc -p .",

--- a/src/constants/special-types.ts
+++ b/src/constants/special-types.ts
@@ -1,1 +1,2 @@
 export const ARRAY = '<SpecialType:Array>';
+export const NULL = 'null';

--- a/src/constants/special-types.ts
+++ b/src/constants/special-types.ts
@@ -1,0 +1,1 @@
+export const ARRAY = '<SpecialType:Array>';

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -25,7 +25,8 @@ export default (children: Child): SlackMessage => {
 
   const result: {blocks?: Block[]} = {};
   if (transformedBlocks.length > 0) {
-    result.blocks = transformedBlocks.concat.apply([], transformedBlocks); // Flatten 1 deep
+    const flattened = transformedBlocks.concat.apply([], transformedBlocks); // Flatten 1 deep
+    result.blocks = flattened.filter((block: Block) => Boolean(block));
   }
 
   return result;

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,5 +1,5 @@
 import {Child, Element} from '../constants/types';
-import {ARRAY} from '../constants/special-types';
+import {ARRAY, NULL} from '../constants/special-types';
 import getType from '../utils/get-type';
 
 import Text from './block/text';
@@ -69,6 +69,10 @@ const doTransform = (elem: Element, type: string): TransformResult => {
 
 export const transform = (elem: Element | Element[]): TransformResult | TransformResult[] => {
   const type = getType(elem);
+
+  if (type === NULL) {
+    return;
+  }
 
   if (type === ARRAY) {
     return (elem as Element[]).map(item => {

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,4 +1,5 @@
 import {Child, Element} from '../constants/types';
+import {ARRAY} from '../constants/special-types';
 import getType from '../utils/get-type';
 
 import Text from './block/text';
@@ -27,6 +28,8 @@ type TransformersType = {
   [index: string]: (child: Child) => {};
 };
 
+type TransformResult = {[index: string]: any};
+
 const Transformers: TransformersType = {
   Container,
   Section,
@@ -54,12 +57,25 @@ const Transformers: TransformersType = {
 
 export default Transformers;
 
-export const transform = (elem: Element): {[index: string]: any} => {
-  const type = getType(elem);
+const doTransform = (elem: Element, type: string): TransformResult => {
+  const transformer = Transformers[type];
 
-  if (!Transformers[type]) {
+  if (!transformer) {
     throw new Error(`No transformer exists for type '${type}'`);
   }
 
-  return Transformers[type](elem);
+  return transformer(elem);
+};
+
+export const transform = (elem: Element | Element[]): TransformResult | TransformResult[] => {
+  const type = getType(elem);
+
+  if (type === ARRAY) {
+    return (elem as Element[]).map(item => {
+      const subType = getType(item);
+      return doTransform(item, subType);
+    });
+  }
+
+  return doTransform(elem as Element, type);
 };

--- a/src/utils/get-type.ts
+++ b/src/utils/get-type.ts
@@ -1,4 +1,5 @@
 import {Child} from '../constants/types';
+import {ARRAY} from '../constants/special-types';
 
 export default (element: Child): string => {
   if (typeof element === 'string') {
@@ -10,7 +11,7 @@ export default (element: Child): string => {
   }
 
   if (Array.isArray(element)) {
-    throw new TypeError('Cannot type arrays');
+    return ARRAY;
   }
 
   const {type} = element;

--- a/src/utils/get-type.ts
+++ b/src/utils/get-type.ts
@@ -1,5 +1,5 @@
 import {Child} from '../constants/types';
-import {ARRAY} from '../constants/special-types';
+import {ARRAY, NULL} from '../constants/special-types';
 
 export default (element: Child): string => {
   if (typeof element === 'string') {
@@ -7,7 +7,7 @@ export default (element: Child): string => {
   }
 
   if (element === null) {
-    return 'null';
+    return NULL;
   }
 
   if (Array.isArray(element)) {

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import proxyquire from 'proxyquire';
 import {stub} from 'sinon';
 
+import renderFn from '../../src/renderer';
 import Message from '../../src/components/message';
 import Text from '../../src/components/block/text';
 import Container from '../../src/components/layout/container';
@@ -139,7 +140,6 @@ test('can render with a container block', t => {
 });
 
 test('can render with an array of blocks', t => {
-  const renderFn = require('../../src/renderer').default;
   const content = [
     <Text>Foo</Text>,
     <Text>Bar</Text>
@@ -151,9 +151,33 @@ test('can render with an array of blocks', t => {
         {content}
       </Container>
     </Message>
-  );
+  ) as unknown;
 
-  console.dir(result, {depth: null})
+  t.deepEqual(result, {
+    text: '',
+    blocks: [
+      {
+        type: 'mrkdwn',
+        text: 'Foo'
+      },
+      {
+        type: 'mrkdwn',
+        text: 'Bar'
+      }
+    ]
+  });
+});
+
+test('ignores nested nulls', t => {
+  const result = renderFn(
+    <Message>
+      <Container>
+        <Text>Foo</Text>
+        {null}
+        <Text>Bar</Text>
+      </Container>
+    </Message>
+  ) as unknown;
 
   t.deepEqual(result, {
     text: '',

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -4,6 +4,7 @@ import proxyquire from 'proxyquire';
 import {stub} from 'sinon';
 
 import Message from '../../src/components/message';
+import Text from '../../src/components/block/text';
 import Container from '../../src/components/layout/container';
 const parser = stub();
 const render = proxyquire('../../src/renderer', {
@@ -135,4 +136,36 @@ test('can render with a container block', t => {
   });
 
   t.true(parser.calledWith(content));
-})
+});
+
+test('can render with an array of blocks', t => {
+  const renderFn = require('../../src/renderer').default;
+  const content = [
+    <Text>Foo</Text>,
+    <Text>Bar</Text>
+  ];
+
+  const result = renderFn(
+    <Message>
+      <Container>
+        {content}
+      </Container>
+    </Message>
+  );
+
+  console.dir(result, {depth: null})
+
+  t.deepEqual(result, {
+    text: '',
+    blocks: [
+      {
+        type: 'mrkdwn',
+        text: 'Foo'
+      },
+      {
+        type: 'mrkdwn',
+        text: 'Bar'
+      }
+    ]
+  });
+});

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -7,6 +7,9 @@ import renderFn from '../../src/renderer';
 import Message from '../../src/components/message';
 import Text from '../../src/components/block/text';
 import Container from '../../src/components/layout/container';
+import Section from '../../src/components/layout/section';
+import Context from '../../src/components/layout/context';
+import Image from '../../src/components/block/image';
 const parser = stub();
 const render = proxyquire('../../src/renderer', {
   '../parser': { default: parser }
@@ -189,6 +192,58 @@ test('ignores nested nulls', t => {
       {
         type: 'mrkdwn',
         text: 'Bar'
+      }
+    ]
+  });
+});
+
+test('can correctly render a complex message', t => {
+  const result = renderFn(
+    <Message color='#FF0000'>
+      <Section text={<Text>Section Header</Text>}>
+        <Text>FooBar</Text>
+        <Image url="someUrl" alt="someAlt"/>
+      </Section>
+      <Context>
+        <Text plainText>Some Context</Text>
+      </Context>
+    </Message>
+  ) as unknown;
+
+  t.deepEqual(result, {
+    text: '',
+    attachments: [
+      {
+        color: '#FF0000',
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: 'Section Header'
+            },
+            fields: [
+              {
+                type: 'mrkdwn',
+                text: 'FooBar'
+              },
+              {
+                type: 'image',
+                url: 'someUrl',
+                alt: 'someAlt'
+              }
+            ]
+          },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'plain_text',
+                text: 'Some Context'
+              }
+            ]
+          }
+        ]
       }
     ]
   });

--- a/test/transformers/transformers.test.tsx
+++ b/test/transformers/transformers.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import test from 'ava';
+import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
+
+const TextTransformer = stub().callsFake(elem => ({
+  type: 'Text',
+  text: elem.props.children
+}));
+
+const transform = proxyquire.noCallThru()('../../src/transformers', {
+  './block/text': TextTransformer
+}).transform;
+
+const Text = (_: {[k: string]: any}): null => null;
+test('it transforms passed element', t => {
+  const result = transform(<Text>Hello!</Text>);
+  t.deepEqual(result, {
+    type: 'Text',
+    text: 'Hello!'
+  });
+});
+
+test('if a transformer does not exist, throw an error', t => {
+  const fn = () => transform(<p>Nope</p>);
+
+  t.throws(fn);
+});
+
+test('can transform an array and return an array', t => {
+  const result = transform([
+    <Text>Foo</Text>,
+    <Text>Bar</Text>
+  ]);
+
+  t.deepEqual(result, [
+    {
+      type: 'Text',
+      text: 'Foo'
+    },
+    {
+      type: 'Text',
+      text: 'Bar'
+    }
+  ]);
+});

--- a/test/utils/get-type.test.tsx
+++ b/test/utils/get-type.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import test from 'ava';
 import getType from '../../src/utils/get-type';
+import { ARRAY } from '../../src/constants/special-types';
 
 class Foo extends React.Component {}
 
@@ -18,4 +19,8 @@ test('it recognizes react elements', t => {
 
 test('it recognizes null', t => {
   t.is(getType(null), 'null');
+});
+
+test('it types arrays as special', t => {
+  t.is(getType([]), ARRAY);
 });


### PR DESCRIPTION
- Adds handling to allow `null` children
  - They are ignored, and not output in the render, allowing for better conditionals

Example:
```jsx
<Section ...>
  <Text>Foo</Text>
  { someCheck ? <Text>Yes!</Text> : null } // If someCheck is false, nothing will be rendered. Mirroring React
</Section>
```

- Adds handling to allow array children
  - Allows for building sections more dynamically

Example:
```jsx
const textParts = [
  <Text>1</Text>
  <Text>2</Text>
  <Text>3</Text>
];
...
<Section ...>
  {textParts} // Mirrors React, by rendering each part as though you had put them in manually
</Section>
```