### PR TITLE
Drop React dependency, replace with custom JSX runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "homepage": "https://github.com/kolyaventuri/block#readme",
   "devDependencies": {
     "@types/node": "25.0.10",
-    "@types/react": "^19.2.9",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
     "@typescript-eslint/parser": "^8.53.1",
     "eslint": "^9.39.2",
@@ -80,15 +79,11 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
-    "react": "^19.2.3",
     "rimraf": "^6.1.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18",
     "xo": "^1.2.3"
-  },
-  "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@slack/types": "^2.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@types/node':
         specifier: 25.0.10
         version: 25.0.10
-      '@types/react':
-        specifier: ^19.2.9
-        version: 19.2.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.53.1
         version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
@@ -53,9 +50,6 @@ importers:
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
-      react:
-        specifier: ^19.2.3
-        version: 19.2.3
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -614,9 +608,6 @@ packages:
   '@types/node@25.0.10':
     resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
 
-  '@types/react@19.2.9':
-    resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
-
   '@typescript-eslint/eslint-plugin@8.53.1':
     resolution: {integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1026,9 +1017,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2184,10 +2172,6 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react@19.2.3:
-    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
-    engines: {node: '>=0.10.0'}
-
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -3183,10 +3167,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/react@19.2.9':
-    dependencies:
-      csstype: 3.2.3
-
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3598,8 +3578,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  csstype@3.2.3: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4881,8 +4859,6 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   react-is@16.13.1: {}
-
-  react@19.2.3: {}
 
   readdirp@4.1.2: {}
 

--- a/src/components/block/button.tsx
+++ b/src/components/block/button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from './confirmation';
 
@@ -12,11 +11,12 @@ type TopProperties = {
 };
 
 export type ButtonProps = TopProperties & {
-  confirm?: React.ReactElement<Confirmation>;
+  confirm?: JSX.Element;
 };
 
 type Properties = ButtonProps;
 
-export default class Button extends React.Component<Properties> {
+export default class Button {
   static slackType = 'Button';
+  declare props: Properties;
 }

--- a/src/components/block/confirmation.tsx
+++ b/src/components/block/confirmation.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-
-import type Text from './text';
 
 type TopProperties = {
   title: string;
@@ -10,11 +7,12 @@ type TopProperties = {
 
 /* This is a dumb workaround to merging props */
 export type ConfirmationProps = TopProperties & {
-  children: React.ReactElement<Text>;
+  children: JSX.Element;
 };
 
 type Properties = ConfirmationProps;
 
-export default class Confirmation extends React.Component<Properties> {
+export default class Confirmation {
   static slackType = 'Confirmation';
+  declare props: Properties;
 }

--- a/src/components/block/image.tsx
+++ b/src/components/block/image.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 
 export type Props = {
   url: string;
   alt: string;
 };
 
-export default class Image extends React.Component<Props> {
+export default class Image {
   static slackType = 'Image';
+  declare props: Props;
 }

--- a/src/components/block/text.tsx
+++ b/src/components/block/text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   children: string;
@@ -7,6 +6,7 @@ export type Props = {
   verbatim?: boolean;
 };
 
-export default class Text extends React.Component<Props> {
+export default class Text {
   static slackType = 'Text';
+  declare props: Props;
 }

--- a/src/components/input/checkboxes.tsx
+++ b/src/components/input/checkboxes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 import {type SingleOrArray} from '../../utils/type-helpers';
@@ -7,12 +6,13 @@ import type Option from './option';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<React.ReactElement<Option>>;
-  initialOptions?: Array<React.ReactElement<Option>>;
-  confirm?: React.ReactElement<Confirmation>;
+  children: SingleOrArray<JSX.Element>;
+  initialOptions?: JSX.Element[];
+  confirm?: JSX.Element;
   focusOnLoad?: boolean;
 };
 
-export default class Checkboxes extends React.Component<Props> {
+export default class Checkboxes {
   static slackType = 'Checkboxes';
+  declare props: Props;
 }

--- a/src/components/input/date-picker.tsx
+++ b/src/components/input/date-picker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 
@@ -6,10 +5,11 @@ export type Props = {
   actionId: string;
   placeholder?: string;
   initialDate?: string;
-  confirm?: React.ReactElement<Confirmation>;
+  confirm?: JSX.Element;
   focusOnLoad?: boolean;
 };
 
-export default class DatePicker extends React.Component<Props> {
+export default class DatePicker {
   static slackType = 'DatePicker';
+  declare props: Props;
 }

--- a/src/components/input/date-time-picker.tsx
+++ b/src/components/input/date-time-picker.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 
 export type Props = {
   actionId: string;
   initialDateTime?: number;
-  confirm?: React.ReactElement<Confirmation>;
+  confirm?: JSX.Element;
   focusOnLoad?: boolean;
 };
 
-export default class DateTimePicker extends React.Component<Props> {
+export default class DateTimePicker {
   static slackType = 'DateTimePicker';
+  declare props: Props;
 }

--- a/src/components/input/option-group.tsx
+++ b/src/components/input/option-group.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 
 import type Option from './option';
 
 export type Props = {
   label: string;
-  children: React.ReactElement<Option> | Array<React.ReactElement<Option>>;
+  children: JSX.Element | JSX.Element[];
 };
 
-export default class OptionGroup extends React.Component<Props> {
+export default class OptionGroup {
   static slackType = 'OptionGroup';
+  declare props: Props;
 }

--- a/src/components/input/option.tsx
+++ b/src/components/input/option.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   children: string;
@@ -7,6 +6,7 @@ export type Props = {
   description?: string;
 };
 
-export default class Option extends React.Component<Props> {
+export default class Option {
   static slackType = 'Option';
+  declare props: Props;
 }

--- a/src/components/input/overflow.tsx
+++ b/src/components/input/overflow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 import {type SingleOrArray} from '../../utils/type-helpers';
@@ -7,10 +6,11 @@ import type Option from './option';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<React.ReactElement<Option>>;
-  confirm?: React.ReactElement<Confirmation>;
+  children: SingleOrArray<JSX.Element>;
+  confirm?: JSX.Element;
 };
 
-export default class Overflow extends React.Component<Props> {
+export default class Overflow {
   static slackType = 'Overflow';
+  declare props: Props;
 }

--- a/src/components/input/radio-group.tsx
+++ b/src/components/input/radio-group.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 import {type SingleOrArray} from '../../utils/type-helpers';
@@ -7,12 +6,13 @@ import type Option from './option';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<React.ReactElement<Option>>;
-  initialOption?: React.ReactElement<Option>;
-  confirm?: React.ReactElement<Confirmation>;
+  children: SingleOrArray<JSX.Element>;
+  initialOption?: JSX.Element;
+  confirm?: JSX.Element;
   focusOnLoad?: boolean;
 };
 
-export default class RadioGroup extends React.Component<Props> {
+export default class RadioGroup {
   static slackType = 'RadioGroup';
+  declare props: Props;
 }

--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 import {type SingleOrArray} from '../../utils/type-helpers';
@@ -27,9 +26,9 @@ export type Props = {
   actionId: string;
   type?: SelectType;
   multi?: boolean;
-  children?: SingleOrArray<React.ReactElement<Option>> | SingleOrArray<React.ReactElement<OptionGroup>>;
-  initialOptions?: Array<React.ReactElement<Option>>;
-  confirm?: React.ReactElement<Confirmation>;
+  children?: SingleOrArray<JSX.Element>;
+  initialOptions?: JSX.Element[];
+  confirm?: JSX.Element;
   maxSelectedItems?: number;
   minQueryLength?: number;
   focusOnLoad?: boolean;
@@ -41,6 +40,7 @@ export type Props = {
   filter?: ConversationFilter;
 };
 
-export default class Select extends React.Component<Props> {
+export default class Select {
   static slackType = 'Select';
+  declare props: Props;
 }

--- a/src/components/input/text.tsx
+++ b/src/components/input/text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   actionId: string;
@@ -13,6 +12,7 @@ export type Props = {
   };
 };
 
-export default class TextInput extends React.Component<Props> {
+export default class TextInput {
   static slackType = 'TextInput';
+  declare props: Props;
 }

--- a/src/components/input/time-picker.tsx
+++ b/src/components/input/time-picker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import type Confirmation from '../block/confirmation';
 
@@ -6,10 +5,11 @@ export type Props = {
   actionId: string;
   placeholder?: string;
   initialTime?: string;
-  confirm?: React.ReactElement<Confirmation>;
+  confirm?: JSX.Element;
   focusOnLoad?: boolean;
 };
 
-export default class TimePicker extends React.Component<Props> {
+export default class TimePicker {
   static slackType = 'TimePicker';
+  declare props: Props;
 }

--- a/src/components/layout/actions.tsx
+++ b/src/components/layout/actions.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type InteractiveBlockElement} from '../../constants/types';
 
@@ -7,6 +6,7 @@ export type Props = {
   blockId?: string;
 };
 
-export default class Actions extends React.Component<Props> {
+export default class Actions {
   static slackType = 'Actions';
+  declare props: Props;
 }

--- a/src/components/layout/container.tsx
+++ b/src/components/layout/container.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 import {type Child} from '../../constants/types';
@@ -7,6 +6,7 @@ export type Props = {
   children: SingleOrArray<Child>;
 };
 
-export default class Container extends React.Component<Props> {
+export default class Container {
   static slackType = 'Container';
+  declare props: Props;
 }

--- a/src/components/layout/context.tsx
+++ b/src/components/layout/context.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
 
 import type Text from '../block/text';
 import type Image from '../block/image';
 
-export type ImageOrText = React.ReactElement<Text> | React.ReactElement<Image>;
+export type ImageOrText = JSX.Element;
 
 export type Props = {
   children: ImageOrText | ImageOrText[];
   blockId?: string;
 };
 
-export default class Context extends React.Component<Props> {
+export default class Context {
   static slackType = 'Context';
+  declare props: Props;
 }

--- a/src/components/layout/divider.tsx
+++ b/src/components/layout/divider.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 
 export type Props = {
   blockId?: string;
 };
 
-export default class Divider extends React.Component<Props> {
+export default class Divider {
   static slackType = 'Divider';
+  declare props: Props;
 }

--- a/src/components/layout/file.tsx
+++ b/src/components/layout/file.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 
 export type Props = {
   externalId: string;
   blockId?: string;
 };
 
-export default class File extends React.Component<Props> {
+export default class File {
   static slackType = 'File';
+  declare props: Props;
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   text: string;
@@ -6,6 +5,7 @@ export type Props = {
   emoji?: boolean;
 };
 
-export default class Header extends React.Component<Props> {
+export default class Header {
   static slackType = 'Header';
+  declare props: Props;
 }

--- a/src/components/layout/image.tsx
+++ b/src/components/layout/image.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   url: string;
@@ -7,6 +6,7 @@ export type Props = {
   blockId?: string;
 };
 
-export default class Image extends React.Component<Props> {
+export default class Image {
   static slackType = 'ImageLayout';
+  declare props: Props;
 }

--- a/src/components/layout/input.tsx
+++ b/src/components/layout/input.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type InputBlockElement} from '../../constants/types';
 
@@ -10,6 +9,7 @@ export type Props = {
   blockId?: string;
 };
 
-export default class Input extends React.Component<Props> {
+export default class Input {
   static slackType = 'Input';
+  declare props: Props;
 }

--- a/src/components/layout/rich-text.tsx
+++ b/src/components/layout/rich-text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 
@@ -6,10 +5,11 @@ export type RichTextElement = Record<string, any>;
 
 export type Props = {
   elements?: RichTextElement[];
-  children?: SingleOrArray<React.ReactElement | string>;
+  children?: SingleOrArray<JSX.Element | string>;
   blockId?: string;
 };
 
-export default class RichText extends React.Component<Props> {
+export default class RichText {
   static slackType = 'RichText';
+  declare props: Props;
 }

--- a/src/components/layout/section.tsx
+++ b/src/components/layout/section.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
 
 import type Text from '../block/text';
 import {type BlockElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
-type TextElement = React.ReactElement<Text>;
+type TextElement = JSX.Element;
 
 export type Props = {
-  text: React.ReactElement<Text>;
+  text: JSX.Element;
   blockId?: string;
   // eslint-disable-next-line @typescript-eslint/no-restricted-types -- We actually want to handle null children
   children?: SingleOrArray<TextElement | null | undefined | false>;
   accessory?: BlockElement;
 };
 
-export default class Section extends React.Component<Props> {
+export default class Section {
   static slackType = 'Section';
+  declare props: Props;
 }

--- a/src/components/layout/video.tsx
+++ b/src/components/layout/video.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   title: string;
@@ -13,6 +12,7 @@ export type Props = {
   blockId?: string;
 };
 
-export default class Video extends React.Component<Props> {
+export default class Video {
   static slackType = 'Video';
+  declare props: Props;
 }

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Child} from '../constants/types';
 
@@ -18,6 +17,7 @@ type Properties = {
   color?: string;
 };
 
-export default class Message extends React.Component<Properties> {
+export default class Message {
   static slackType = 'Message';
+  declare props: Properties;
 }

--- a/src/components/rich-text/broadcast.tsx
+++ b/src/components/rich-text/broadcast.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type RichTextBroadcastRange} from './types';
 
@@ -6,6 +5,7 @@ export type Props = {
   range: RichTextBroadcastRange;
 };
 
-export default class RichTextBroadcast extends React.Component<Props> {
+export default class RichTextBroadcast {
   static slackType = 'RichTextBroadcast';
+  declare props: Props;
 }

--- a/src/components/rich-text/channel.tsx
+++ b/src/components/rich-text/channel.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 
 export type Props = {
   channelId: string;
 };
 
-export default class RichTextChannel extends React.Component<Props> {
+export default class RichTextChannel {
   static slackType = 'RichTextChannel';
+  declare props: Props;
 }

--- a/src/components/rich-text/date.tsx
+++ b/src/components/rich-text/date.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export type Props = {
   timestamp: number;
@@ -7,6 +6,7 @@ export type Props = {
   link?: string;
 };
 
-export default class RichTextDate extends React.Component<Props> {
+export default class RichTextDate {
   static slackType = 'RichTextDate';
+  declare props: Props;
 }

--- a/src/components/rich-text/emoji.tsx
+++ b/src/components/rich-text/emoji.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 
 export type Props = {
   name: string;
 };
 
-export default class RichTextEmoji extends React.Component<Props> {
+export default class RichTextEmoji {
   static slackType = 'RichTextEmoji';
+  declare props: Props;
 }

--- a/src/components/rich-text/link.tsx
+++ b/src/components/rich-text/link.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type RichTextStyle} from './types';
 
@@ -8,6 +7,7 @@ export type Props = {
   style?: RichTextStyle;
 };
 
-export default class RichTextLink extends React.Component<Props> {
+export default class RichTextLink {
   static slackType = 'RichTextLink';
+  declare props: Props;
 }

--- a/src/components/rich-text/list.tsx
+++ b/src/components/rich-text/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 
@@ -6,11 +5,12 @@ import {type RichTextListStyle} from './types';
 
 export type Props = {
   style: RichTextListStyle;
-  children: SingleOrArray<React.ReactElement | string>;
+  children: SingleOrArray<JSX.Element | string>;
   indent?: number;
   border?: number;
 };
 
-export default class RichTextList extends React.Component<Props> {
+export default class RichTextList {
   static slackType = 'RichTextList';
+  declare props: Props;
 }

--- a/src/components/rich-text/preformatted.tsx
+++ b/src/components/rich-text/preformatted.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<React.ReactElement | string>;
+  children: SingleOrArray<JSX.Element | string>;
 };
 
-export default class RichTextPreformatted extends React.Component<Props> {
+export default class RichTextPreformatted {
   static slackType = 'RichTextPreformatted';
+  declare props: Props;
 }

--- a/src/components/rich-text/quote.tsx
+++ b/src/components/rich-text/quote.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<React.ReactElement | string>;
+  children: SingleOrArray<JSX.Element | string>;
 };
 
-export default class RichTextQuote extends React.Component<Props> {
+export default class RichTextQuote {
   static slackType = 'RichTextQuote';
+  declare props: Props;
 }

--- a/src/components/rich-text/section.tsx
+++ b/src/components/rich-text/section.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<React.ReactElement | string>;
+  children: SingleOrArray<JSX.Element | string>;
 };
 
-export default class RichTextSection extends React.Component<Props> {
+export default class RichTextSection {
   static slackType = 'RichTextSection';
+  declare props: Props;
 }

--- a/src/components/rich-text/text.tsx
+++ b/src/components/rich-text/text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type RichTextStyle} from './types';
 
@@ -7,6 +6,7 @@ export type Props = {
   style?: RichTextStyle;
 };
 
-export default class RichTextText extends React.Component<Props> {
+export default class RichTextText {
   static slackType = 'RichTextText';
+  declare props: Props;
 }

--- a/src/components/rich-text/user-group.tsx
+++ b/src/components/rich-text/user-group.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 
 export type Props = {
   usergroupId: string;
 };
 
-export default class RichTextUserGroup extends React.Component<Props> {
+export default class RichTextUserGroup {
   static slackType = 'RichTextUserGroup';
+  declare props: Props;
 }

--- a/src/components/rich-text/user.tsx
+++ b/src/components/rich-text/user.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 
 export type Props = {
   userId: string;
 };
 
-export default class RichTextUser extends React.Component<Props> {
+export default class RichTextUser {
   static slackType = 'RichTextUser';
+  declare props: Props;
 }

--- a/src/constants/types.d.ts
+++ b/src/constants/types.d.ts
@@ -1,4 +1,3 @@
-import {type ReactElement} from 'react';
 import {type Block as SlackBlock, type KnownBlock, type MessageAttachment} from '@slack/types';
 
 import {type TextType as TextInputType} from '../transformers/input/text';
@@ -88,11 +87,11 @@ export type SerializedElement =
 export type Block = KnownBlock | SlackBlock;
 export type Attachment = MessageAttachment;
 
-export type InteractiveBlockElement = ReactElement<any, any>;
-export type StandardBlockElement = ReactElement<any, any>;
+export type InteractiveBlockElement = JSX.Element;
+export type StandardBlockElement = JSX.Element;
 
-export type InputBlockElement = ReactElement<any, any>;
-export type BlockElement = InteractiveBlockElement | StandardBlockElement | InputBlockElement;
+export type InputBlockElement = JSX.Element;
+export type BlockElement = JSX.Element;
 
 type SlackMessageContents =
   | Omit<ChannelAndText, 'channel'>
@@ -136,7 +135,7 @@ type AnyConstructor = new (...parameters: any[]) => any;
 export type WithType = {
   type?: string | AnyFunction | AnyConstructor;
 };
-export type BElement = ReactElement<any, any> & WithType;
+export type BElement = JSX.Element & WithType;
 export type Element = BElement;
 export type Child =
   | string

--- a/src/jsx-dev-runtime.ts
+++ b/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export {jsx as jsxDEV, Fragment} from './jsx-runtime';

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,12 @@
+export function jsx(type: any, props: any) {
+  const {children} = props;
+
+  return {
+    type,
+    props,
+    children: Array.isArray(children) ? children : (children === undefined ? [] : [children]),
+  };
+}
+
+export const jsxs = jsx;
+export const Fragment = 'fragment';

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,0 +1,6 @@
+declare namespace JSX {
+  export type Element = {type: any; props: any; children: any[]};
+  export type IntrinsicElements = Record<string, any>;
+  export type ElementClass = {props: any};
+  export type ElementAttributesProperty = {props: Record<string, any>};
+}

--- a/src/transformers/block/button.tsx
+++ b/src/transformers/block/button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type ButtonProps} from '../../components/block/button';

--- a/src/transformers/block/confirmation.tsx
+++ b/src/transformers/block/confirmation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {transform} from '../transform';

--- a/src/transformers/input/date-picker.tsx
+++ b/src/transformers/input/date-picker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Props as DatePickerProperties} from '../../components/input/date-picker';
 import {type Element} from '../../constants/types';

--- a/src/transformers/input/option-group.tsx
+++ b/src/transformers/input/option-group.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import Text from '../../components/block/text';
 import {type Props as OptionGroupProperties} from '../../components/input/option-group';

--- a/src/transformers/input/option.tsx
+++ b/src/transformers/input/option.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';

--- a/src/transformers/input/select.tsx
+++ b/src/transformers/input/select.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';
@@ -67,7 +66,7 @@ const types = {
 };
 const MULTI_PREFIX = 'multi_';
 
-const normalizeElements = (elements?: SelectProperties['children']): React.ReactElement[] => {
+const normalizeElements = (elements?: SelectProperties['children']): JSX.Element[] => {
   if (!elements) {
     return [];
   }
@@ -75,7 +74,7 @@ const normalizeElements = (elements?: SelectProperties['children']): React.React
   return Array.isArray(elements) ? elements : [elements];
 };
 
-const assignStaticOptions = (elements: React.ReactElement[], result: SelectType): void => {
+const assignStaticOptions = (elements: JSX.Element[], result: SelectType): void => {
   const elementType = getType(elements[0] as Element);
   if (elements.some(element => getType(element as Element) !== elementType)) {
     if (elementType === OPTION && elements.some(element => getType(element as Element) !== OPTION_GROUP)) {
@@ -88,11 +87,9 @@ const assignStaticOptions = (elements: React.ReactElement[], result: SelectType)
   }
 
   if (elementType === OPTION) {
-    const options = elements as Array<React.ReactElement<Option>>;
-    result.options = options.map(element => transform(element as Element)) as OptionType[];
+    result.options = elements.map(element => transform(element as Element)) as OptionType[];
   } else if (elementType === OPTION_GROUP) {
-    const optionGroups = elements as Array<React.ReactElement<OptionGroup>>;
-    result.option_groups = optionGroups.map(element => transform(element as Element)) as OptionGroupType[];
+    result.option_groups = elements.map(element => transform(element as Element)) as OptionGroupType[];
   }
 };
 
@@ -101,7 +98,7 @@ const applyInitialSelections = (
   isMulti: boolean,
   result: SelectType,
   initialValues: {
-    initialOptions?: Array<React.ReactElement<Option>>;
+    initialOptions?: JSX.Element[];
     initialUsers?: string[];
     initialConversations?: string[];
     initialChannels?: string[];

--- a/src/transformers/input/text.tsx
+++ b/src/transformers/input/text.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import Text from '../../components/block/text';
 import {type Props as TextInputProperties} from '../../components/input/text';

--- a/src/transformers/input/time-picker.tsx
+++ b/src/transformers/input/time-picker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';

--- a/src/transformers/layout/header.tsx
+++ b/src/transformers/layout/header.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type Props as HeaderProperties} from '../../components/layout/header';

--- a/src/transformers/layout/image.tsx
+++ b/src/transformers/layout/image.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';

--- a/src/transformers/layout/input.tsx
+++ b/src/transformers/layout/input.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element, type SerializedInputBlockElement} from '../../constants/types';
 import {type TextType} from '../block/text';

--- a/src/transformers/layout/video.tsx
+++ b/src/transformers/layout/video.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import {type Element} from '../../constants/types';
 import {type Props as VideoProperties} from '../../components/layout/video';

--- a/test/e2e/pipeline.test.tsx
+++ b/test/e2e/pipeline.test.tsx
@@ -3,7 +3,6 @@
  * These tests use the public render() API and assert on the final output,
  * unlike the unit tests which test individual transformer functions.
  */
-import React from 'react';
 import {test, expect, describe} from 'vitest';
 
 import render from '../../src';

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,5 +1,4 @@
 import {test, expect} from 'vitest';
-import React from 'react';
 
 import render from '../src';
 import Message from '../src/components/message';

--- a/test/parser/parser.test.tsx
+++ b/test/parser/parser.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   beforeEach,
   expect,

--- a/test/parser/transformer-routing.test.tsx
+++ b/test/parser/transformer-routing.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import parser from '../../src/parser';

--- a/test/renderer/renderer.test.tsx
+++ b/test/renderer/renderer.test.tsx
@@ -4,7 +4,6 @@ import {
   test,
   vi,
 } from 'vitest';
-import React from 'react';
 
 import Message from '../../src/components/message';
 import Container from '../../src/components/layout/container';

--- a/test/transformers/block/button.test.tsx
+++ b/test/transformers/block/button.test.tsx
@@ -1,5 +1,4 @@
 import {test, expect} from 'vitest';
-import React from 'react';
 
 import transformer from '../../../src/transformers/block/button';
 import confirmTransformer from '../../../src/transformers/block/confirmation';

--- a/test/transformers/block/confirmation.test.tsx
+++ b/test/transformers/block/confirmation.test.tsx
@@ -1,5 +1,4 @@
 import {test, expect} from 'vitest';
-import React from 'react';
 
 import transformer from '../../../src/transformers/block/confirmation';
 import Confirmation from '../../../src/components/block/confirmation';

--- a/test/transformers/block/image.test.tsx
+++ b/test/transformers/block/image.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/block/image';

--- a/test/transformers/block/text.test.tsx
+++ b/test/transformers/block/text.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import Text from '../../../src/components/block/text';

--- a/test/transformers/input/checkboxes.test.tsx
+++ b/test/transformers/input/checkboxes.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/input/checkboxes';

--- a/test/transformers/input/date-picker.test.tsx
+++ b/test/transformers/input/date-picker.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/date-picker';

--- a/test/transformers/input/date-time-picker.test.tsx
+++ b/test/transformers/input/date-time-picker.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/input/date-time-picker';

--- a/test/transformers/input/option-group.test.tsx
+++ b/test/transformers/input/option-group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/option-group';

--- a/test/transformers/input/option.test.tsx
+++ b/test/transformers/input/option.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/option';

--- a/test/transformers/input/overflow.test.tsx
+++ b/test/transformers/input/overflow.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/overflow';

--- a/test/transformers/input/radio-group.test.tsx
+++ b/test/transformers/input/radio-group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/radio-group';

--- a/test/transformers/input/select.test.tsx
+++ b/test/transformers/input/select.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/select';

--- a/test/transformers/input/text.test.tsx
+++ b/test/transformers/input/text.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/input/text';

--- a/test/transformers/input/time-picker.test.tsx
+++ b/test/transformers/input/time-picker.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/input/time-picker';

--- a/test/transformers/layout/actions.test.tsx
+++ b/test/transformers/layout/actions.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/actions';

--- a/test/transformers/layout/container.test.tsx
+++ b/test/transformers/layout/container.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import Container from '../../../src/components/layout/container';

--- a/test/transformers/layout/context.test.tsx
+++ b/test/transformers/layout/context.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/context';

--- a/test/transformers/layout/divider.test.tsx
+++ b/test/transformers/layout/divider.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/divider';

--- a/test/transformers/layout/file.test.tsx
+++ b/test/transformers/layout/file.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/file';

--- a/test/transformers/layout/header.test.tsx
+++ b/test/transformers/layout/header.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/header';

--- a/test/transformers/layout/image.test.tsx
+++ b/test/transformers/layout/image.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/image';

--- a/test/transformers/layout/input.test.tsx
+++ b/test/transformers/layout/input.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/input';

--- a/test/transformers/layout/rich-text.test.tsx
+++ b/test/transformers/layout/rich-text.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/rich-text';

--- a/test/transformers/layout/section.test.tsx
+++ b/test/transformers/layout/section.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import Section from '../../../src/components/layout/section';

--- a/test/transformers/layout/video.test.tsx
+++ b/test/transformers/layout/video.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/layout/video';

--- a/test/transformers/rich-text/list.test.tsx
+++ b/test/transformers/rich-text/list.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/rich-text/list';

--- a/test/transformers/rich-text/section.test.tsx
+++ b/test/transformers/rich-text/section.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {expect, test} from 'vitest';
 
 import transformer from '../../../src/transformers/rich-text/section';

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,13 +1,19 @@
 {
   "compilerOptions": {
+    "baseUrl": "..",
     "noImplicitAny": true,
     "removeComments": true,
     "target": "es2019",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": ["node", "react"],
+    "types": ["node"],
     "lib": ["es2019", "dom", "esnext.disposable"],
-    "jsx": "react",
-    "esModuleInterop": true
-  }
+    "jsx": "react-jsx",
+    "jsxImportSource": "jsx-runtime",
+    "esModuleInterop": true,
+    "paths": {
+      "jsx-runtime/jsx-runtime": ["./src/jsx-runtime.ts"]
+    }
+  },
+  "include": ["./**/*", "../src/jsx.d.ts"]
 }

--- a/test/utils/get-type.test.tsx
+++ b/test/utils/get-type.test.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
 import {test, expect} from 'vitest';
 
 import getType from '../../src/utils/get-type';
 
-class Foo extends React.Component {}
+class Foo {
+  static slackType = 'Foo';
+  declare props: Record<string, unknown>;
+}
 
 test('it recognizes strings', () => {
   expect(getType('Hello')).toBe('string');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,13 @@
     "target": "es2019",
     "module": "Node16",
     "moduleResolution": "node16",
-    "types": ["react"],
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "jsxImportSource": "jsx-runtime",
     "baseUrl": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "paths": {
+      "jsx-runtime/jsx-runtime": ["./src/jsx-runtime.ts"]
+    }
   },
   "exclude": ["node_modules", "test/**/*"],
   "include": ["src"] 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -6,9 +8,14 @@ export default defineConfig({
     include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
     setupFiles: ['./test/setup.ts'],
   },
+  resolve: {
+    alias: {
+      'jsx-runtime/jsx-runtime': path.resolve('./src/jsx-runtime.ts'),
+      'jsx-runtime/jsx-dev-runtime': path.resolve('./src/jsx-dev-runtime.ts'),
+    },
+  },
   esbuild: {
-    jsx: 'transform',
-    jsxFactory: 'React.createElement',
-    jsxFragment: 'React.Fragment',
+    jsx: 'automatic',
+    jsxImportSource: 'jsx-runtime',
   },
 });

--- a/xo.config.cjs
+++ b/xo.config.cjs
@@ -5,7 +5,6 @@ module.exports = [
   },
   {
     space: true,
-    react: true,
     files: ['**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
@@ -16,11 +15,6 @@ module.exports = [
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@stylistic/jsx-quotes': ['error', 'prefer-double'],
-      'react/jsx-indent': 'off',
-      'react/jsx-indent-props': 'off',
-      'react/jsx-closing-bracket-location': 'off',
-      'react/jsx-closing-tag-location': 'off',
-      'react/jsx-sort-props': 'off',
       'import-x/no-cycle': 'error',
       'import-x/order': [
         'error',
@@ -41,10 +35,6 @@ module.exports = [
           tsx: 'never'
         }
       ],
-      'react/no-unused-prop-types': 'off',
-      'react/prefer-read-only-props': 'off',
-      'react/require-default-props': 'off',
-      'react/style-prop-object': 'off',
       'unicorn/prevent-abbreviations': [
         'error',
         {
@@ -59,7 +49,6 @@ module.exports = [
           }
         }
       ],
-      'react/jsx-fragments': ['error', 'element'],
       '@typescript-eslint/naming-convention': [
         'error',
         {
@@ -82,9 +71,6 @@ module.exports = [
         node: {
           extensions: ['.js', '.jsx', '.ts', '.tsx', '.d.ts', '.cjs', '.mjs', '.json']
         }
-      },
-      react: {
-        version: 'detect'
       }
     }
   }


### PR DESCRIPTION
## Summary

- Removes `react` and `@types/react` as dependencies, replacing them with a minimal custom JSX runtime (`src/jsx-runtime.ts`)
- Replaces all `React.Component<P>` base classes with standalone classes using `declare props: P` (TypeScript reads prop types via `JSX.ElementAttributesProperty`)
- Replaces `React.ReactElement<T>` with the global `JSX.Element` type declared in `src/jsx.d.ts`
- Updates Vitest/esbuild config to use the `automatic` JSX transform pointed at the custom runtime
- Removes `react` plugin from the xo ESLint config

## Key implementation details

- `src/jsx.d.ts` (renamed from `jsx-runtime.d.ts`) — TypeScript was silently ignoring the old filename because it shadowed the `jsx-runtime.ts` module; moving to a different name makes it a proper global ambient declaration
- `src/jsx-runtime.ts` — keeps `children` in `props` for backward compatibility with all existing transformers that read `child.props.children`
- `src/jsx-dev-runtime.ts` — required by esbuild's `jsx: automatic` in dev/test mode

## Test plan

- [x] `pnpm test:tsc` — no TypeScript errors
- [x] `pnpm test:lint` — no lint errors
- [x] `pnpm test:unit` — all 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)