### PR TITLE
Phase F: documentation, component reference, JSDoc, and migration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,254 @@
 # SlackBlock
-JSX-based Slack message renderer
+
+JSX-based Slack Block Kit message renderer
 
 [![CI](https://github.com/kolyaventuri/block/actions/workflows/ci.yml/badge.svg)](https://github.com/kolyaventuri/block/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/slackblock)](https://www.npmjs.com/package/slackblock)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/types-included-blue)](https://www.typescriptlang.org/)
 
-## What
-A message builder for Slack bots, using JSX with a React-compatible API. Generally follows the [Block Kit](https://api.slack.com/block-kit) naming and options.
+Build Slack messages with JSX. No React required — SlackBlock ships its own lightweight JSX runtime. Write your blocks as components, call `render()`, and post the result straight to the Slack API.
+
+---
 
 ## Compatibility
 
 | | Supported |
 |---|---|
-| Node.js | >= 20 |
-| TypeScript | >= 5.0 |
+| Node.js | `>= 20` |
+| TypeScript | `>= 5.0` |
 | React | Not required — uses a built-in JSX runtime |
 
-## Getting started
-Install the library with your package manager, for example `pnpm add slackblock`.
+---
 
-- Import the renderer with `import render from 'slackblock';`
-- Import the top level `Message` block, along with any blocks you need from `import { Message, Section, Text, ... } from 'slackblock/block';`
-- Build your message!
-```jsx
-/* example */
+## Install
 
-const text = <Text plainText>Hello</Text>;
+```sh
+npm install slackblock
+# or
+pnpm add slackblock
+# or
+yarn add slackblock
+```
 
-const message = render(
-  <Message>
-    <Section text={text}>
-      <Text>Some *message* for _Slack_.</Text>
-    </Section>
-  </Message>
-);
+---
 
-console.log(message);
-/*
-  {
-    "blocks": [
-      {
-        "type": "section",
-        "text": {
-          "type": "plain_text",
-          "text": "Hello"
-        },
-        "fields": [
-          {
-            "type": "mrkdwn",
-            "text": "Some *message* for _Slack_."
-          }
-        ]
-      }
-    ]
+## TypeScript setup
+
+Add the following options to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "slackblock"
   }
-*/
+}
 ```
 
-There is a `<Container/>` component, which allows for conditional rendering by passing through the children as though it didn't exist.
-```jsx
-const elem = (
-  <Container>
-    <Text>Test</Text>
-  </Container>
-);
+This tells TypeScript to use SlackBlock's built-in JSX runtime instead of React.
 
-const shouldDoThing = ...;
+---
+
+## Quick start
+
+```tsx
+import render from 'slackblock';
+import { Message, Section, Text, Header, Divider, Actions, Button } from 'slackblock/block';
 
 const message = render(
-  <Message>
-    {shouldDoThing && elem}
+  <Message text="Deployment complete">
+    <Header text="Deploy finished" />
+    <Section text={<Text>Service *api* deployed to production.</Text>} />
+    <Divider />
+    <Actions>
+      <Button actionId="view_logs" url="https://example.com/logs">View logs</Button>
+      <Button actionId="rollback" style="danger">Rollback</Button>
+    </Actions>
   </Message>
 );
+
+// message is ready to post — just add your channel:
+await slackClient.chat.postMessage({ channel: '#deploys', ...message });
 ```
 
-## Things to note
-- The outputted message only needs to have your `token` and desired `channel_id` added, and it will be ready to send to the slack API!
-- No React dependency — uses a built-in JSX runtime.
-- There is limited input validation (for example, date/time formats and select constraints). Warnings are emitted for common Slack limits (IDs, text lengths, block counts). Non-recognized blocks will be ignored, but Slack will be the ultimate decider if your message is valid. Validation is on the roadmap.
-- There is currently almost no documentation. This will be resolved, but in general...
-  - If a Slack message wants a property in format `foo_bar`, you will add it as a `fooBar` property in your message(ex: `<Element fooBar='blah'/>`)
-  - If a component such as a `<Section/>` wants fields which seem like children, they probably are for the sake of rendering. This is especially important with `select` menus, as your `<Option/>` tags will be passed as children
-    - ex:
-     ```jsx
-       <Select ...>
-         <Option value="val">text</Option>
-         <Option value="val2">text2</Option>
-       </Select>
-     ``` 
+The rendered output is a plain object you can spread directly into `chat.postMessage`.
 
-## Supported blocks and elements
-Blocks: `Message` (top-level), `Section`, `Actions`, `Context`, `Divider`, `File`, `Image` (block), `Header`, `Input`, `RichText`, `Video`.
+---
 
-Elements: `Text`, `Image` (element), `Button`, `Confirmation`, `Select`, `Option`, `OptionGroup`, `Overflow`, `RadioGroup`, `Checkboxes`, `DatePicker`, `TimePicker`, `DateTimePicker`, `TextInput`.
+## API
 
-Rich text helpers: `RichTextSection`, `RichTextList`, `RichTextQuote`, `RichTextPreformatted`, `RichTextText`, `RichTextLink`, `RichTextUser`, `RichTextChannel`, `RichTextEmoji`, `RichTextDate`, `RichTextBroadcast`, `RichTextUserGroup`.
+### `render(element, options?)` — default export
 
-Field support highlights: `select` filters/min query length, `option` description, `focusOnLoad` for inputs, `dispatchActionConfig` for text inputs, and `accessibilityLabel` on buttons.
+Renders a `<Message>` tree to a full Slack message payload.
 
+```ts
+import render from 'slackblock';
 
-## TODO
-- Add real documentation
-- Add validation
-- Add richer rich_text validation
+const message = render(<Message text="Hello">...</Message>);
+// → { text: "Hello", blocks: [...] }
+```
+
+The top-level element must be a `<Message>`. Throws a `TypeError` otherwise.
+
+### `renderToMessage(element, options?)`
+
+Named alias for `render`. Use whichever reads more naturally in your codebase.
+
+```ts
+import { renderToMessage } from 'slackblock';
+```
+
+### `renderToBlocks(element, options?)`
+
+Renders any JSX element (or fragment) directly to a `Block[]` array, without a `<Message>` wrapper. Useful for modals and home tabs, which accept a `blocks` array rather than a full message payload.
+
+```tsx
+import { renderToBlocks } from 'slackblock';
+import { Section, Text } from 'slackblock/block';
+
+const blocks = renderToBlocks(
+  <>
+    <Section text={<Text>Hello from a modal</Text>} />
+  </>
+);
+// → [{ type: "section", text: { type: "mrkdwn", text: "Hello from a modal" } }]
+```
+
+### `blockKitBuilderUrl(blocks)`
+
+Returns a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL for the given blocks. Open it in a browser to preview layout and interactivity during development.
+
+```ts
+import { renderToBlocks, blockKitBuilderUrl } from 'slackblock';
+
+const blocks = renderToBlocks(<Section text={<Text>Hello</Text>} />);
+console.log(blockKitBuilderUrl(blocks));
+// → https://app.slack.com/block-kit-builder#{"blocks":[...]}
+```
+
+### `escapeMrkdwn(text)`
+
+Escapes Slack mrkdwn special characters (`*`, `_`, `~`, `` ` ``, `>`, `&`, `<`, `>`) in a string. Use this when inserting untrusted user content into a mrkdwn text field.
+
+```ts
+import { escapeMrkdwn } from 'slackblock';
+
+const safe = escapeMrkdwn(userInput); // "hello *world*" → "hello \*world\*"
+```
+
+### Options
+
+Both `render` / `renderToMessage` / `renderToBlocks` accept an optional `options` object:
+
+```ts
+type RenderOptions = {
+  validate?: 'off' | 'warn' | 'strict'; // default: 'warn'
+};
+```
+
+See [docs/validation.md](docs/validation.md) for details.
+
+---
+
+## Validation
+
+SlackBlock validates your message against Slack's documented limits and required fields. The `validate` option controls what happens when a violation is detected:
+
+| Mode | Behavior |
+|------|----------|
+| `'warn'` (default) | Logs a warning to `console.warn`; rendering continues |
+| `'strict'` | Throws a `SlackblockValidationError` |
+| `'off'` | No validation |
+
+```tsx
+// Throw on any violation — recommended for tests
+const message = render(<Message>...</Message>, { validate: 'strict' });
+```
+
+```ts
+import { SlackblockValidationError } from 'slackblock';
+
+try {
+  render(<Message>...</Message>, { validate: 'strict' });
+} catch (err) {
+  if (err instanceof SlackblockValidationError) {
+    console.error(err.message); // "Message > Header: Header text exceeds 150 characters."
+    console.error(err.path);    // ["Message", "Header"]
+    console.error(err.rule);    // "too-long"
+  }
+}
+```
+
+See [docs/validation.md](docs/validation.md) for the full rule reference.
+
+---
+
+## Conventions
+
+**camelCase props** — Slack's API uses `snake_case`; SlackBlock uses `camelCase` props that map to the correct API fields:
+
+```tsx
+// Slack API: { "block_id": "...", "action_id": "..." }
+<Button blockId="my_block" actionId="my_action">Click me</Button>
+```
+
+**Children as fields** — When Slack expects an array (e.g. select options, section fields), pass them as JSX children:
+
+```tsx
+<Select placeholder="Pick one" actionId="pick">
+  <Option value="a">Option A</Option>
+  <Option value="b">Option B</Option>
+</Select>
+```
+
+**Conditional rendering** — Use `<Container>` to wrap elements that may or may not render, or use standard JS short-circuit expressions:
+
+```tsx
+<Message text="Hello">
+  {isAdmin && <Section text={<Text>Admin panel</Text>} />}
+  <Container>
+    {items.map(item => <Section key={item.id} text={<Text>{item.name}</Text>} />)}
+  </Container>
+</Message>
+```
+
+**Color / attachment** — Setting `color` on `<Message>` wraps blocks in a legacy attachment for the colored left border. `color` accepts any hex value or Slack named colors:
+
+```tsx
+<Message text="Alert" color="#ff0000">
+  <Section text={<Text>Something went wrong.</Text>} />
+</Message>
+```
+
+---
+
+## Supported components
+
+**Layout blocks:** `Message`, `Section`, `Actions`, `Context`, `Divider`, `File`, `Header`, `Image` (block), `Input`, `RichText`, `Video`
+
+**Block elements:** `Text`, `Image` (element), `Button`, `Confirmation`
+
+**Input elements:** `Select`, `Option`, `OptionGroup`, `Overflow`, `Checkboxes`, `RadioGroup`, `TextInput`, `DatePicker`, `TimePicker`, `DateTimePicker`
+
+**Rich text helpers:** `RichTextSection`, `RichTextList`, `RichTextQuote`, `RichTextPreformatted`, `RichTextText`, `RichTextLink`, `RichTextUser`, `RichTextChannel`, `RichTextEmoji`, `RichTextDate`, `RichTextBroadcast`, `RichTextUserGroup`
+
+**Utility:** `Container`
+
+See [docs/components.md](docs/components.md) for the full props reference.
+
+---
+
+## Further reading
+
+- [Component reference](docs/components.md) — all components with props tables
+- [Validation guide](docs/validation.md) — validation modes and error handling
+- [Migrating from jsx-slack](docs/migrating-from-jsx-slack.md)
+- [Migrating from slack-block-builder](docs/migrating-from-slack-block-builder.md)
+- [Slack Block Kit reference](https://api.slack.com/block-kit)
+
+---
+
+## License
+
+MIT

--- a/UPGRADE_PLAN.md
+++ b/UPGRADE_PLAN.md
@@ -135,17 +135,18 @@ Acceptance criteria:
 
 ---
 
-### Phase F — Documentation and adoption
+### Phase F — Documentation and adoption ✅
 
-- [ ] Rewrite README: value proposition, install + quick start, compatibility matrix,
+- [x] Rewrite README: value proposition, install + quick start, compatibility matrix,
       validation mode overview, links to examples.
-- [ ] Add component reference (one entry per public component, props table).
-- [ ] Add examples for: message, modal, home tab.
-- [ ] Add migration guides from `jsx-slack` and `slack-block-builder`.
+- [x] Add component reference (`docs/components.md` — one entry per public component, props table).
+- [x] Add migration guides from `jsx-slack` and `slack-block-builder`.
+- [x] Add JSDoc to all public components, render functions, and key utilities.
+- [ ] Add examples for: message, modal, home tab (JSX source files, not just JSON fixtures).
 
 Acceptance criteria:
-- [ ] A new user can build and send a valid message in under 10 minutes from the README.
-- [ ] Migration guides exist for at least two alternatives.
+- [x] A new user can build and send a valid message in under 10 minutes from the README.
+- [x] Migration guides exist for at least two alternatives.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,786 @@
+# Component Reference
+
+All components are imported from `slackblock/block`:
+
+```ts
+import {
+  Message, Section, Header, Actions, Context,
+  // ...
+} from 'slackblock/block';
+```
+
+---
+
+## Layout blocks
+
+These are the top-level building blocks of a Slack message or modal.
+
+---
+
+### `<Message>`
+
+The required root element for `render()` / `renderToMessage()`. Represents a Slack chat message.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `JSX.Element \| JSX.Element[]` | Yes | Block elements to include in the message |
+| `text` | `string` | — | Fallback text shown in notifications and when blocks cannot render |
+| `color` | `string` | — | Hex color (e.g. `"#36a64f"`) or named color. Wraps blocks in a legacy attachment for a colored left border |
+| `username` | `string` | — | Override the bot's display name |
+| `iconEmoji` | `string` | — | Override the bot's icon with an emoji (e.g. `":robot_face:"`) |
+| `iconUrl` | `string` | — | Override the bot's icon with an image URL |
+| `asUser` | `boolean` | — | Post as the authenticated user instead of the bot |
+| `markdown` | `boolean` | — | Set `mrkdwn` field. Defaults to Slack's own default (`true`) |
+| `parse` | `'full' \| 'none'` | — | Text parsing mode |
+| `replyTo` | `string` | — | Thread timestamp (`thread_ts`) to reply to |
+| `replyBroadcast` | `boolean` | — | Also send the reply to the channel |
+| `unfurlLinks` | `boolean` | — | Unfurl links in the message |
+| `unfurlMedia` | `boolean` | — | Unfurl media (images, videos) in the message |
+
+```tsx
+<Message text="Fallback" color="#36a64f" username="Deploy Bot" iconEmoji=":rocket:">
+  <Header text="Deploy complete" />
+</Message>
+```
+
+---
+
+### `<Section>`
+
+A section block. Supports a text label, optional fields column, and an optional accessory element.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `text` | `JSX.Element` | Yes | Primary text — typically a `<Text>` element |
+| `blockId` | `string` | — | Unique identifier for the block |
+| `children` | `<Text> \| <Text>[]` | — | Fields displayed in a two-column grid below the text |
+| `accessory` | block element | — | An interactive element displayed to the right |
+
+```tsx
+<Section
+  text={<Text>Hello *Block Kit*.</Text>}
+  accessory={<Button actionId="more">More</Button>}
+>
+  <Text plainText>Field A</Text>
+  <Text plainText>Field B</Text>
+</Section>
+```
+
+---
+
+### `<Header>`
+
+A header block displaying large, bold text.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `text` | `string` | Yes | Plain text content (max 150 characters) |
+| `blockId` | `string` | — | Unique identifier for the block |
+| `emoji` | `boolean` | — | Allow emoji in the header text |
+
+```tsx
+<Header text="Welcome to the team!" emoji />
+```
+
+---
+
+### `<Actions>`
+
+An actions block containing interactive elements displayed in a row.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | interactive element(s) | Yes | `<Button>`, `<Select>`, `<Overflow>`, `<DatePicker>`, `<TimePicker>`, `<DateTimePicker>` |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<Actions>
+  <Button actionId="approve" style="primary">Approve</Button>
+  <Button actionId="deny" style="danger">Deny</Button>
+</Actions>
+```
+
+---
+
+### `<Context>`
+
+A context block displaying a row of small text and images.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `<Text>` or `<Image>` element(s) | Yes | Up to 10 text or image elements |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<Context>
+  <Image url="https://example.com/avatar.png" alt="avatar" />
+  <Text>Posted by *Jane Doe*</Text>
+</Context>
+```
+
+---
+
+### `<Divider>`
+
+A horizontal rule that visually separates blocks.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<Divider />
+```
+
+---
+
+### `<Input>`
+
+A block that wraps a single interactive input element with a label.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `label` | `string` | Yes | Input label text (max 2000 characters) |
+| `element` | input element | Yes | The input element: `<TextInput>`, `<Select>`, `<DatePicker>`, etc. |
+| `hint` | `string` | — | Hint text shown below the input |
+| `optional` | `boolean` | — | Mark the field as optional |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<Input label="Your name" hint="Use your full name">
+  {/* element prop, not children */}
+</Input>
+
+// Correct usage:
+<Input
+  label="Your name"
+  element={<TextInput actionId="name" placeholder="Jane Doe" />}
+/>
+```
+
+---
+
+### `<Image>` (layout block)
+
+An image block that displays a full-width image.
+
+> Import as `ImageLayout` to disambiguate from the `<Image>` element.
+
+```ts
+import { ImageLayout } from 'slackblock/block';
+```
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `url` | `string` | Yes | URL of the image |
+| `alt` | `string` | Yes | Alt text for accessibility |
+| `title` | `string` | — | Title displayed above the image |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<ImageLayout
+  url="https://example.com/chart.png"
+  alt="Sales chart"
+  title="Q4 Results"
+/>
+```
+
+---
+
+### `<File>`
+
+A file block that embeds a remote file shared in Slack.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `externalId` | `string` | Yes | The external ID of the remote file |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<File externalId="my-file-id" />
+```
+
+---
+
+### `<Video>`
+
+A video block that embeds an external video.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | `string` | Yes | Video title (max 200 characters) |
+| `videoUrl` | `string` | Yes | URL of the video |
+| `thumbnailUrl` | `string` | Yes | URL of the thumbnail image |
+| `altText` | `string` | Yes | Alt text for the thumbnail |
+| `titleUrl` | `string` | — | URL the title links to |
+| `description` | `string` | — | Description text (max 200 characters) |
+| `authorName` | `string` | — | Author name |
+| `providerName` | `string` | — | Video provider name (e.g. `"YouTube"`) |
+| `providerIconUrl` | `string` | — | URL of the provider icon |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<Video
+  title="Product Demo"
+  videoUrl="https://example.com/demo.mp4"
+  thumbnailUrl="https://example.com/thumb.png"
+  altText="Product demo video"
+  authorName="Product Team"
+/>
+```
+
+---
+
+### `<RichText>`
+
+A rich text block for rendering formatted text with inline styling, lists, quotes, and code.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | rich text element(s) | Yes | `<RichTextSection>`, `<RichTextList>`, `<RichTextQuote>`, `<RichTextPreformatted>` |
+| `blockId` | `string` | — | Unique identifier for the block |
+
+```tsx
+<RichText>
+  <RichTextSection>
+    <RichTextText style={{ bold: true }}>Hello</RichTextText>
+  </RichTextSection>
+</RichText>
+```
+
+---
+
+### `<Container>`
+
+A utility component that renders its children as-is without adding any wrapper block. Useful for conditional rendering and for mapping arrays of elements without introducing an extra layer.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | JSX element(s) | Yes | Any block elements |
+
+```tsx
+<Message text="Hello">
+  {isAdmin && (
+    <Container>
+      <Section text={<Text>Admin section</Text>} />
+      <Divider />
+    </Container>
+  )}
+</Message>
+```
+
+---
+
+## Block elements
+
+Elements used as props or inside other blocks (not standalone blocks).
+
+---
+
+### `<Text>`
+
+Renders a mrkdwn or plain_text text object. Used as the `text` prop on `<Section>`, in `<Context>`, and other places.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `string` | Yes | The text content |
+| `plainText` | `boolean` | — | Use `plain_text` type instead of `mrkdwn` |
+| `emoji` | `boolean` | — | Render emoji in plain text mode |
+| `verbatim` | `boolean` | — | Disable automatic link detection in mrkdwn |
+
+```tsx
+<Text>Hello *world*</Text>
+<Text plainText emoji>Hello :wave:</Text>
+```
+
+---
+
+### `<Image>` (element)
+
+An image element used inside `<Context>` or as a `<Section>` accessory.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `url` | `string` | Yes | URL of the image |
+| `alt` | `string` | Yes | Alt text for accessibility |
+
+```tsx
+<Context>
+  <Image url="https://example.com/icon.png" alt="icon" />
+  <Text>Some context</Text>
+</Context>
+```
+
+---
+
+### `<Button>`
+
+A button element.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `string` | Yes | Button label (max 75 characters) |
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `value` | `string` | — | Value sent with the action payload |
+| `url` | `string` | — | URL to open when the button is clicked |
+| `style` | `'primary' \| 'danger'` | — | Button style |
+| `accessibilityLabel` | `string` | — | Screen reader label (max 75 characters) |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog before triggering the action |
+
+```tsx
+<Button actionId="submit" style="primary" value="yes">Submit</Button>
+<Button actionId="delete" style="danger" confirm={<Confirmation ...>}>Delete</Confirmation>
+```
+
+---
+
+### `<Confirmation>`
+
+A confirmation dialog attached to interactive elements.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | `string` | Yes | Dialog title (max 300 characters) |
+| `confirm` | `string` | Yes | Text of the confirm button |
+| `deny` | `string` | Yes | Text of the cancel button |
+| `children` | `<Text>` | Yes | Body text of the dialog |
+
+```tsx
+const confirmDialog = (
+  <Confirmation title="Are you sure?" confirm="Yes, delete" deny="Cancel">
+    <Text plainText>This action cannot be undone.</Text>
+  </Confirmation>
+);
+
+<Button actionId="delete" confirm={confirmDialog}>Delete</Button>
+```
+
+---
+
+## Input elements
+
+Interactive form controls, used as the `element` prop inside `<Input>` or as children of `<Actions>`.
+
+---
+
+### `<TextInput>`
+
+A plain text input field.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `placeholder` | `string` | — | Placeholder text |
+| `initial` | `string` | — | Initial value |
+| `multiline` | `boolean` | — | Show as a textarea |
+| `minLength` | `number` | — | Minimum character count |
+| `maxLength` | `number` | — | Maximum character count (max 3000) |
+| `focusOnLoad` | `boolean` | — | Auto-focus this input when the view loads |
+| `dispatchActionConfig` | `{ triggerActionsOn: Array<'on_enter_pressed' \| 'on_character_entered'> }` | — | When to dispatch block actions |
+
+```tsx
+<Input label="Your message">
+  {/* pass as element prop */}
+</Input>
+
+<Input
+  label="Your message"
+  element={
+    <TextInput
+      actionId="msg"
+      placeholder="Type here..."
+      multiline
+      maxLength={500}
+    />
+  }
+/>
+```
+
+---
+
+### `<Select>`
+
+A dropdown select menu. Supports static, external, user, conversation, and channel list types, as well as multi-select.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `placeholder` | `string` | Yes | Placeholder text |
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `type` | `'static' \| 'external' \| 'user' \| 'conversation' \| 'channel'` | — | Data source (default: `'static'`) |
+| `multi` | `boolean` | — | Allow multiple selections |
+| `children` | `<Option> \| <OptionGroup>` | — | Options (for `static` type) |
+| `initialOptions` | `<Option>[]` | — | Pre-selected options |
+| `initialUsers` | `string[]` | — | Pre-selected user IDs (for `user` type) |
+| `initialConversations` | `string[]` | — | Pre-selected conversation IDs |
+| `initialChannels` | `string[]` | — | Pre-selected channel IDs |
+| `maxSelectedItems` | `number` | — | Maximum selections (multi only) |
+| `minQueryLength` | `number` | — | Minimum query length (external type) |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+| `defaultToCurrentConversation` | `boolean` | — | Pre-select the current conversation |
+| `responseUrlEnabled` | `boolean` | — | Include response URL in the payload |
+| `filter` | `ConversationFilter` | — | Filter conversation list |
+
+```tsx
+// Static single-select
+<Select placeholder="Pick one" actionId="color">
+  <Option value="red">Red</Option>
+  <Option value="blue">Blue</Option>
+</Select>
+
+// User multi-select
+<Select type="user" multi placeholder="Pick users" actionId="mentions" />
+```
+
+---
+
+### `<Option>`
+
+An option item for `<Select>`, `<Checkboxes>`, `<RadioGroup>`, or `<Overflow>`.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `string` | Yes | Display label |
+| `value` | `string` | Yes | Value sent in the action payload |
+| `description` | `string` | — | Secondary text shown below the label |
+| `url` | `string` | — | URL to open (overflow menus only) |
+
+```tsx
+<Option value="opt_a" description="The first option">Option A</Option>
+```
+
+---
+
+### `<OptionGroup>`
+
+Groups options under a label in a static or external `<Select>`.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `label` | `string` | Yes | Group label |
+| `children` | `<Option> \| <Option>[]` | Yes | Options in the group |
+
+```tsx
+<Select placeholder="Pick one" actionId="grouped">
+  <OptionGroup label="Fruits">
+    <Option value="apple">Apple</Option>
+    <Option value="banana">Banana</Option>
+  </OptionGroup>
+  <OptionGroup label="Vegetables">
+    <Option value="carrot">Carrot</Option>
+  </OptionGroup>
+</Select>
+```
+
+---
+
+### `<Checkboxes>`
+
+A group of checkboxes.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `children` | `<Option> \| <Option>[]` | Yes | Checkbox options |
+| `initialOptions` | `<Option>[]` | — | Pre-checked options |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+
+```tsx
+<Checkboxes actionId="prefs" initialOptions={[optionA]}>
+  <Option value="a">Option A</Option>
+  <Option value="b">Option B</Option>
+</Checkboxes>
+```
+
+---
+
+### `<RadioGroup>`
+
+A group of radio buttons (single selection).
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `children` | `<Option> \| <Option>[]` | Yes | Radio options |
+| `initialOption` | `<Option>` | — | Pre-selected option |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+
+```tsx
+<RadioGroup actionId="size" initialOption={<Option value="m">Medium</Option>}>
+  <Option value="s">Small</Option>
+  <Option value="m">Medium</Option>
+  <Option value="l">Large</Option>
+</RadioGroup>
+```
+
+---
+
+### `<Overflow>`
+
+An overflow menu (the "..." button) with a list of options.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `children` | `<Option> \| <Option>[]` | Yes | Menu options (minimum 2) |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+
+```tsx
+<Overflow actionId="more">
+  <Option value="edit">Edit</Option>
+  <Option value="delete">Delete</Option>
+  <Option value="docs" url="https://example.com/docs">View docs</Option>
+</Overflow>
+```
+
+---
+
+### `<DatePicker>`
+
+A date picker input.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `placeholder` | `string` | — | Placeholder text |
+| `initialDate` | `string` | — | Initial date in `YYYY-MM-DD` format |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+
+```tsx
+<DatePicker actionId="due_date" initialDate="2024-12-31" placeholder="Select a date" />
+```
+
+---
+
+### `<TimePicker>`
+
+A time picker input.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `placeholder` | `string` | — | Placeholder text |
+| `initialTime` | `string` | — | Initial time in `HH:mm` (24-hour) format |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+
+```tsx
+<TimePicker actionId="meeting_time" initialTime="09:00" />
+```
+
+---
+
+### `<DateTimePicker>`
+
+A combined date and time picker.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `actionId` | `string` | Yes | Unique identifier for the action |
+| `initialDateTime` | `number` | — | Initial Unix timestamp |
+| `confirm` | `<Confirmation>` | — | Confirmation dialog |
+| `focusOnLoad` | `boolean` | — | Auto-focus on view load |
+
+```tsx
+<DateTimePicker actionId="scheduled_at" initialDateTime={1700000000} />
+```
+
+---
+
+## Rich text elements
+
+Used inside `<RichText>` to compose formatted text content.
+
+---
+
+### `<RichTextSection>`
+
+An inline container for rich text elements within a `<RichText>` block.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | rich text element(s) or string(s) | Yes | Inline rich text content |
+
+```tsx
+<RichTextSection>
+  <RichTextText style={{ bold: true }}>Hello</RichTextText>
+  {' '}
+  <RichTextText>world</RichTextText>
+</RichTextSection>
+```
+
+---
+
+### `<RichTextText>`
+
+Styled text within a rich text section.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | `string` | Yes | The text content |
+| `style` | `{ bold?: boolean; italic?: boolean; strike?: boolean; code?: boolean }` | — | Text style |
+
+```tsx
+<RichTextText style={{ bold: true, italic: true }}>Bold italic</RichTextText>
+```
+
+---
+
+### `<RichTextLink>`
+
+A hyperlink within rich text.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `url` | `string` | Yes | Link URL |
+| `children` | `string` | — | Link text (shows URL if omitted) |
+| `style` | `{ bold?: boolean; italic?: boolean; strike?: boolean; code?: boolean }` | — | Text style |
+
+```tsx
+<RichTextLink url="https://example.com" style={{ bold: true }}>Visit us</RichTextLink>
+```
+
+---
+
+### `<RichTextList>`
+
+A bulleted or numbered list.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `style` | `'bullet' \| 'ordered'` | Yes | List style |
+| `children` | `<RichTextSection>[]` | Yes | List items — each item should be a `<RichTextSection>` |
+| `indent` | `number` | — | Indent level (0–6) |
+| `border` | `number` | — | Border style |
+
+```tsx
+<RichTextList style="bullet">
+  <RichTextSection><RichTextText>First item</RichTextText></RichTextSection>
+  <RichTextSection><RichTextText>Second item</RichTextText></RichTextSection>
+</RichTextList>
+```
+
+---
+
+### `<RichTextQuote>`
+
+A blockquote within rich text.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | rich text element(s) or string(s) | Yes | Quoted content |
+
+```tsx
+<RichTextQuote>
+  <RichTextText>This is a quoted passage.</RichTextText>
+</RichTextQuote>
+```
+
+---
+
+### `<RichTextPreformatted>`
+
+A preformatted code block within rich text.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `children` | rich text element(s) or string(s) | Yes | Preformatted content |
+
+```tsx
+<RichTextPreformatted>
+  <RichTextText style={{ code: true }}>const x = 1;</RichTextText>
+</RichTextPreformatted>
+```
+
+---
+
+### `<RichTextUser>`
+
+Mentions a Slack user by ID.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `userId` | `string` | Yes | Slack user ID (e.g. `"U123456"`) |
+
+```tsx
+<RichTextUser userId="U123456" />
+```
+
+---
+
+### `<RichTextChannel>`
+
+Mentions a Slack channel by ID.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `channelId` | `string` | Yes | Slack channel ID (e.g. `"C123456"`) |
+
+```tsx
+<RichTextChannel channelId="C123456" />
+```
+
+---
+
+### `<RichTextUserGroup>`
+
+Mentions a Slack user group by ID.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `usergroupId` | `string` | Yes | Slack user group ID (e.g. `"S123456"`) |
+
+```tsx
+<RichTextUserGroup usergroupId="S123456" />
+```
+
+---
+
+### `<RichTextEmoji>`
+
+Renders an emoji by name.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | Emoji name without colons (e.g. `"wave"`) |
+
+```tsx
+<RichTextEmoji name="wave" />
+```
+
+---
+
+### `<RichTextBroadcast>`
+
+A `@here`, `@channel`, or `@everyone` mention.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `range` | `'here' \| 'channel' \| 'everyone'` | Yes | Broadcast range |
+
+```tsx
+<RichTextBroadcast range="here" />
+```
+
+---
+
+### `<RichTextDate>`
+
+Renders a formatted date that adapts to the viewer's timezone.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `timestamp` | `number` | Yes | Unix timestamp |
+| `format` | `string` | Yes | [Slack date format string](https://api.slack.com/reference/surfaces/formatting#date-formatting) (e.g. `"{date_num} {time}"`) |
+| `fallback` | `string` | Yes | Text shown if the timestamp cannot be rendered |
+
+```tsx
+<RichTextDate
+  timestamp={1700000000}
+  format="{date_long} at {time}"
+  fallback="Nov 14, 2023 at 22:13"
+/>
+```

--- a/docs/migrating-from-jsx-slack.md
+++ b/docs/migrating-from-jsx-slack.md
@@ -1,0 +1,152 @@
+# Migrating from jsx-slack
+
+[jsx-slack](https://github.com/yhatt/jsx-slack) is a JSX-based Slack Block Kit library. Both libraries follow a similar JSX approach, but differ in component names, rendering API, and how text / fields are composed.
+
+---
+
+## Key differences
+
+| | jsx-slack | slackblock |
+|---|---|---|
+| JSX runtime | Own runtime (`jsxImportSource: "jsx-slack"`) | Own runtime (`jsxImportSource: "slackblock"`) |
+| Surface container | `<Blocks>` | `<Message>` for messages; `renderToBlocks()` for modals/home tabs |
+| Section fields | `<Field>` children | `<Text>` children |
+| Confirmation | `<Confirm>` | `<Confirmation>` |
+| Mrkdwn text | HTML-like tags (`<b>`, `<i>`, inline HTML) | `<Text>` with mrkdwn syntax, or `<RichText>` components |
+| Template literals | `jsxslack` tag | Not supported |
+| Validation | Throws on invalid props | Configurable: `'off'`, `'warn'` (default), `'strict'` |
+
+---
+
+## TypeScript setup
+
+Both libraries use the modern JSX transform — just swap the import source:
+
+**jsx-slack:**
+```json
+{
+  "compilerOptions": {
+    "jsxImportSource": "jsx-slack"
+  }
+}
+```
+
+**slackblock:**
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "slackblock"
+  }
+}
+```
+
+---
+
+## Rendering a message
+
+**jsx-slack:**
+```tsx
+import { Blocks, Section } from 'jsx-slack';
+
+const blocks = (
+  <Blocks>
+    <Section>Hello</Section>
+  </Blocks>
+);
+```
+
+**slackblock:**
+```tsx
+import render from 'slackblock';
+import { Message, Section, Text } from 'slackblock/block';
+
+const message = render(
+  <Message text="Hello">
+    <Section text={<Text>Hello</Text>} />
+  </Message>
+);
+```
+
+For modals and home tabs (blocks array only):
+```tsx
+import { renderToBlocks } from 'slackblock';
+import { Section, Text } from 'slackblock/block';
+
+const blocks = renderToBlocks(<Section text={<Text>Hello</Text>} />);
+```
+
+---
+
+## Section text and fields
+
+**jsx-slack** accepts text as children directly, with HTML-like formatting:
+```tsx
+<Section>
+  Hello <b>world</b>
+  <Field>Field A</Field>
+  <Field>Field B</Field>
+</Section>
+```
+
+**slackblock** separates concerns explicitly:
+- `text` prop for the primary text (a `<Text>` element with mrkdwn)
+- Children of `<Section>` become fields
+
+```tsx
+<Section text={<Text>Hello *world*</Text>}>
+  <Text>Field A</Text>
+  <Text>Field B</Text>
+</Section>
+```
+
+---
+
+## Confirmation dialogs
+
+**jsx-slack:** `<Confirm>` component
+
+**slackblock:** `<Confirmation>` component (note the full name)
+
+```tsx
+const dialog = (
+  <Confirmation title="Are you sure?" confirm="Yes, delete" deny="Cancel">
+    <Text plainText>This action cannot be undone.</Text>
+  </Confirmation>
+);
+
+<Button actionId="delete" confirm={dialog} style="danger">Delete</Button>
+```
+
+---
+
+## Input blocks
+
+**jsx-slack:** Input element is a child of `<Input>`:
+```tsx
+<Input label="Name">
+  <TextInput actionId="name" />
+</Input>
+```
+
+**slackblock:** Input element goes in the `element` prop:
+```tsx
+<Input
+  label="Name"
+  element={<TextInput actionId="name" />}
+/>
+```
+
+---
+
+## Validation
+
+**jsx-slack** throws on invalid props by default.
+
+**slackblock** defaults to `'warn'` mode. To match jsx-slack's behavior:
+
+```tsx
+render(<Message>...</Message>, { validate: 'strict' });
+```
+
+See [validation.md](./validation.md) for details.

--- a/docs/migrating-from-slack-block-builder.md
+++ b/docs/migrating-from-slack-block-builder.md
@@ -1,0 +1,252 @@
+# Migrating from slack-block-builder
+
+[slack-block-builder](https://github.com/raycharius/slack-block-builder) uses a fluent builder API (method chaining). This guide maps the builder pattern to slackblock's JSX approach.
+
+---
+
+## Key differences
+
+| | slack-block-builder | slackblock |
+|---|---|---|
+| Syntax | Fluent builder (method chaining) | JSX |
+| Output | Call `.buildToJSON()` or `.buildToObject()` | Plain JS object, ready to spread |
+| Select variants | Separate classes per source type (`StaticSelect`, `UserSelect`, etc.) | Single `<Select>` with a `type` prop |
+| Confirmation dialog | `ConfirmationDialog()` builder | `<Confirmation>` component |
+| Radio buttons | `RadioButtons()` / `RadioButton()` | `<RadioGroup>` / `<Option>` |
+| Overflow menu | `OverflowMenu()` | `<Overflow>` |
+| Modals / home tabs | `Modal()`, `HomeTab()` builders | `renderToBlocks()` |
+| Validation | Runtime validation on `.build()` | Configurable: `'off'`, `'warn'`, `'strict'` |
+
+---
+
+## TypeScript setup
+
+**slack-block-builder** needs no TSConfig changes.
+
+**slackblock** uses the modern JSX transform:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "slackblock"
+  }
+}
+```
+
+---
+
+## Basic message
+
+**slack-block-builder:**
+```ts
+import { Message, Blocks } from 'slack-block-builder';
+
+const msg = Message()
+  .text('Hello')
+  .blocks(
+    Blocks.Section({ text: 'Hello *Block Kit*.' }),
+    Blocks.Divider(),
+  )
+  .buildToJSON();
+```
+
+**slackblock:**
+```tsx
+import render from 'slackblock';
+import { Message, Section, Text, Divider } from 'slackblock/block';
+
+const msg = render(
+  <Message text="Hello">
+    <Section text={<Text>Hello *Block Kit*.</Text>} />
+    <Divider />
+  </Message>
+);
+```
+
+The result is already a plain object — no `.buildToJSON()` step needed.
+
+---
+
+## Spreading into `chat.postMessage`
+
+**slack-block-builder:**
+```ts
+await client.chat.postMessage({
+  channel: '#general',
+  ...Message().text('Hello').blocks(...).buildToJSON(),
+});
+```
+
+**slackblock:**
+```tsx
+await client.chat.postMessage({
+  channel: '#general',
+  ...render(<Message text="Hello"><Section text={<Text>Hello</Text>} /></Message>),
+});
+```
+
+---
+
+## Blocks for modals and home tabs
+
+**slack-block-builder:**
+```ts
+import { Modal, Blocks, Elements } from 'slack-block-builder';
+
+const modal = Modal({ title: 'My Modal' })
+  .blocks(
+    Blocks.Input({ label: 'Name' })
+      .element(Elements.TextInput({ actionId: 'name' })),
+  )
+  .buildToObject();
+```
+
+**slackblock:**
+```tsx
+import { renderToBlocks } from 'slackblock';
+import { Input, TextInput } from 'slackblock/block';
+
+const blocks = renderToBlocks(
+  <Input label="Name" element={<TextInput actionId="name" />} />
+);
+
+await client.views.open({
+  trigger_id: triggerId,
+  view: {
+    type: 'modal',
+    title: { type: 'plain_text', text: 'My Modal' },
+    blocks,
+  },
+});
+```
+
+---
+
+## Sections
+
+**slack-block-builder:**
+```ts
+Blocks.Section()
+  .text('Primary text')
+  .fields('Field one', 'Field two')
+  .accessory(Elements.Button({ text: 'Click', actionId: 'btn' }))
+```
+
+**slackblock:**
+```tsx
+<Section
+  text={<Text>Primary text</Text>}
+  accessory={<Button actionId="btn">Click</Button>}
+>
+  <Text>Field one</Text>
+  <Text>Field two</Text>
+</Section>
+```
+
+Fields are passed as children of `<Section>`.
+
+---
+
+## Select menus
+
+slack-block-builder has separate classes per data source; slackblock uses a single `<Select>` with a `type` prop:
+
+| slack-block-builder | slackblock |
+|---|---|
+| `Elements.StaticSelect()` | `<Select>` (default, `type="static"`) |
+| `Elements.ExternalSelect()` | `<Select type="external">` |
+| `Elements.UserSelect()` | `<Select type="user">` |
+| `Elements.ConversationSelect()` | `<Select type="conversation">` |
+| `Elements.ChannelSelect()` | `<Select type="channel">` |
+| Multi-variants | Add `multi` prop to any `<Select>` |
+
+```tsx
+// Static single-select
+<Select placeholder="Pick one" actionId="color">
+  <Option value="red">Red</Option>
+  <Option value="blue">Blue</Option>
+</Select>
+
+// User multi-select
+<Select type="user" multi placeholder="Pick users" actionId="mentions" />
+```
+
+---
+
+## Radio buttons
+
+**slack-block-builder:** `RadioButtons()` builder with `RadioButton()` items.
+
+**slackblock:** `<RadioGroup>` with `<Option>` children:
+
+```tsx
+<RadioGroup actionId="size">
+  <Option value="s">Small</Option>
+  <Option value="m">Medium</Option>
+  <Option value="l">Large</Option>
+</RadioGroup>
+```
+
+---
+
+## Overflow menu
+
+**slack-block-builder:** `Elements.OverflowMenu()` builder.
+
+**slackblock:** `<Overflow>` with `<Option>` children:
+
+```tsx
+<Overflow actionId="more">
+  <Option value="edit">Edit</Option>
+  <Option value="delete">Delete</Option>
+</Overflow>
+```
+
+---
+
+## Confirmation dialogs
+
+**slack-block-builder:** `Bits.ConfirmationDialog()` builder.
+
+**slackblock:** `<Confirmation>` component passed via the `confirm` prop:
+
+```tsx
+const dialog = (
+  <Confirmation title="Are you sure?" confirm="Yes, delete" deny="Cancel">
+    <Text plainText>This cannot be undone.</Text>
+  </Confirmation>
+);
+
+<Button actionId="delete" confirm={dialog} style="danger">Delete</Button>
+```
+
+---
+
+## Validation
+
+**slack-block-builder** validates on `.build()` and throws on invalid input.
+
+**slackblock** defaults to `'warn'` mode (console warnings). To match the throwing behavior:
+
+```tsx
+render(<Message>...</Message>, { validate: 'strict' });
+```
+
+See [validation.md](./validation.md) for the full validation reference.
+
+---
+
+## Preview in Block Kit Builder
+
+**slack-block-builder** includes a Block Kit Builder URL helper.
+
+**slackblock** has `blockKitBuilderUrl`:
+
+```ts
+import { renderToBlocks, blockKitBuilderUrl } from 'slackblock';
+
+const blocks = renderToBlocks(<Section text={<Text>Hello</Text>} />);
+console.log(blockKitBuilderUrl(blocks));
+// → https://app.slack.com/block-kit-builder#{"blocks":[...]}
+```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,203 @@
+# Validation
+
+SlackBlock validates your JSX against Slack's documented limits and required fields before rendering. This catches mistakes early — during development or in tests — rather than at Slack API call time.
+
+---
+
+## Validation modes
+
+Pass `validate` in the options object to any render function:
+
+```ts
+render(element, { validate: 'strict' });
+renderToMessage(element, { validate: 'strict' });
+renderToBlocks(element, { validate: 'strict' });
+```
+
+| Mode | Default? | Behavior |
+|------|----------|----------|
+| `'warn'` | Yes | Logs a warning via `console.warn`; rendering continues |
+| `'strict'` | — | Throws a `SlackblockValidationError`; rendering halts |
+| `'off'` | — | No validation; no output |
+
+### Choosing a mode
+
+- **`'warn'`** — good for production. Violations are logged but don't crash your bot.
+- **`'strict'`** — recommended for tests. Use it to ensure your message templates are valid before deploying.
+- **`'off'`** — use only when you're deliberately constructing payloads that bend the rules or when validation overhead is a concern.
+
+---
+
+## `SlackblockValidationError`
+
+Thrown in `'strict'` mode. Import it for `instanceof` checks:
+
+```ts
+import { SlackblockValidationError } from 'slackblock';
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | `string` | Full error message including path (e.g. `"Message > Header: Header text exceeds 150 characters."`) |
+| `path` | `string` | Component path at the point of failure (e.g. `"Message > Header"`) |
+| `rule` | `string` | Rule identifier (see table below) |
+
+### Example
+
+```ts
+try {
+  render(
+    <Message text="Hello">
+      <Header text={"x".repeat(200)} />
+    </Message>,
+    { validate: 'strict' }
+  );
+} catch (err) {
+  if (err instanceof SlackblockValidationError) {
+    console.error(err.message);
+    // → "Message > Header: Header text exceeds 150 characters."
+
+    console.error(err.path);
+    // → "Message > Header"
+
+    console.error(err.rule);
+    // → "too-long"
+  }
+}
+```
+
+---
+
+## Validation rules
+
+### `required-field`
+
+Triggered when a required prop is missing from a component.
+
+Applies to: `Button` (`actionId`), `Select` (`actionId`, `placeholder`), `TextInput` (`actionId`), `DatePicker` (`actionId`), `TimePicker` (`actionId`), `DateTimePicker` (`actionId`), `Checkboxes` (`actionId`), `RadioGroup` (`actionId`), `Overflow` (`actionId`).
+
+```tsx
+// Triggers required-field violation:
+<Button>Submit</Button>
+//       ^^^ missing actionId
+```
+
+### `too-long`
+
+Triggered when a string prop exceeds Slack's documented character limit.
+
+| Component / Prop | Limit |
+|------------------|-------|
+| `Message.text` (hard limit) | 40,000 chars |
+| `Message.text` (recommended) | 4,000 chars |
+| `Header.text` | 150 chars |
+| `Button` label | 75 chars |
+| `Button.accessibilityLabel` | 75 chars |
+| `Button.value` | 2,000 chars |
+| `Option` label | 75 chars |
+| `Option.value` | 150 chars |
+| `Option.description` | 75 chars |
+| `Option.url` | 3,000 chars |
+| `OptionGroup.label` | 75 chars |
+| `Image.url` | 3,000 chars |
+| `Image.alt` | 2,000 chars |
+| `Image.title` | 2,000 chars |
+| `blockId` | 255 chars |
+| `actionId` | 255 chars |
+| `placeholder` | 150 chars |
+
+### `too-many`
+
+Triggered when a collection exceeds Slack's documented count limit.
+
+| Component / Collection | Limit |
+|------------------------|-------|
+| `Message` blocks | 50 |
+| `Section` fields (children) | 10 |
+| `Actions` elements | 25 |
+| `Context` elements | 10 |
+| `OptionGroup` options | 100 |
+
+### `invalid-format`
+
+Triggered when a date or time prop does not match the required format.
+
+| Prop | Required format |
+|------|----------------|
+| `DatePicker.initialDate` | `YYYY-MM-DD` |
+| `TimePicker.initialTime` | `HH:mm` (24-hour) |
+
+### `unknown-type`
+
+Triggered when a component is not recognized by SlackBlock's transformer registry. Unrecognized components are silently dropped from the output unless validation is strict.
+
+---
+
+## Testing with strict mode
+
+Use `validate: 'strict'` in your test suite to catch validation issues early:
+
+```ts
+import { describe, it, expect } from 'vitest'; // or jest, mocha, etc.
+import render, { SlackblockValidationError } from 'slackblock';
+import { Message, Header } from 'slackblock/block';
+
+describe('my message', () => {
+  it('renders without validation errors', () => {
+    expect(() =>
+      render(
+        <Message text="Hello">
+          <Header text="Welcome" />
+        </Message>,
+        { validate: 'strict' }
+      )
+    ).not.toThrow();
+  });
+
+  it('throws on oversized header', () => {
+    expect(() =>
+      render(
+        <Message text="Hello">
+          <Header text={"x".repeat(200)} />
+        </Message>,
+        { validate: 'strict' }
+      )
+    ).toThrow(SlackblockValidationError);
+  });
+});
+```
+
+---
+
+## `escapeMrkdwn`
+
+A utility for safely inserting untrusted user content into mrkdwn text fields.
+
+```ts
+import { escapeMrkdwn } from 'slackblock';
+```
+
+Escapes the following characters:
+- `&` → `&amp;`
+- `<` → `&lt;`
+- `>` → `&gt;`
+- `*`, `_`, `~`, `` ` `` → prepended with a zero-width space to prevent formatting
+
+### Example
+
+```tsx
+import render, { escapeMrkdwn } from 'slackblock';
+import { Message, Section, Text } from 'slackblock/block';
+
+const userComment = 'Hello *world* <script>';
+const safe = escapeMrkdwn(userComment);
+// → "Hello \u200B*world\u200B* &lt;script&gt;"
+
+render(
+  <Message text="New comment">
+    <Section text={<Text>{safe}</Text>} />
+  </Message>
+);
+```

--- a/src/components/block/button.tsx
+++ b/src/components/block/button.tsx
@@ -14,6 +14,17 @@ export type ButtonProps = TopProperties & {
 
 type Properties = ButtonProps;
 
+/**
+ * A button element — clickable button used in `<Actions>` blocks or as a
+ * `<Section>` accessory.
+ *
+ * @example
+ * ```tsx
+ * <Button actionId="submit" style="primary" value="yes">Submit</Button>
+ * <Button actionId="delete" style="danger" confirm={confirmDialog}>Delete</Button>
+ * <Button actionId="docs" url="https://example.com">View docs</Button>
+ * ```
+ */
 export default class Button {
   static slackType = 'Button';
   declare props: Properties;

--- a/src/components/block/confirmation.tsx
+++ b/src/components/block/confirmation.tsx
@@ -12,6 +12,23 @@ export type ConfirmationProps = TopProperties & {
 
 type Properties = ConfirmationProps;
 
+/**
+ * A confirmation dialog — shown before an interactive action is triggered.
+ *
+ * Pass a `<Confirmation>` element to the `confirm` prop of interactive
+ * elements such as `<Button>`, `<Select>`, `<Overflow>`, etc.
+ *
+ * @example
+ * ```tsx
+ * const dialog = (
+ *   <Confirmation title="Are you sure?" confirm="Yes, delete" deny="Cancel">
+ *     <Text plainText>This action cannot be undone.</Text>
+ *   </Confirmation>
+ * );
+ *
+ * <Button actionId="delete" confirm={dialog} style="danger">Delete</Button>
+ * ```
+ */
 export default class Confirmation {
   static slackType = 'Confirmation';
   declare props: Properties;

--- a/src/components/block/image.tsx
+++ b/src/components/block/image.tsx
@@ -4,6 +4,20 @@ export type Props = {
   alt: string;
 };
 
+/**
+ * An image element — displays an inline image inside `<Context>` or as a
+ * `<Section>` accessory.
+ *
+ * For a full-width image block, use `<ImageLayout>` instead.
+ *
+ * @example
+ * ```tsx
+ * <Context>
+ *   <Image url="https://example.com/icon.png" alt="icon" />
+ *   <Text>Some context</Text>
+ * </Context>
+ * ```
+ */
 export default class Image {
   static slackType = 'Image';
   declare props: Props;

--- a/src/components/block/text.tsx
+++ b/src/components/block/text.tsx
@@ -6,6 +6,18 @@ export type Props = {
   verbatim?: boolean;
 };
 
+/**
+ * A text object — renders as `mrkdwn` (default) or `plain_text`.
+ *
+ * Used as the `text` prop on `<Section>`, `<Header>`, inside `<Context>`,
+ * and as a child of `<Section>` for fields.
+ *
+ * @example
+ * ```tsx
+ * <Text>Hello *world*</Text>
+ * <Text plainText emoji>Hello :wave:</Text>
+ * ```
+ */
 export default class Text {
   static slackType = 'Text';
   declare props: Props;

--- a/src/components/input/checkboxes.tsx
+++ b/src/components/input/checkboxes.tsx
@@ -9,6 +9,19 @@ export type Props = {
   focusOnLoad?: boolean;
 };
 
+/**
+ * A checkbox group — allows multiple selections from a list of options.
+ *
+ * Pass `<Option>` elements as children. Pre-check options via `initialOptions`.
+ *
+ * @example
+ * ```tsx
+ * <Checkboxes actionId="prefs" initialOptions={[slackOption]}>
+ *   <Option value="emails">Emails</Option>
+ *   <Option value="slack">Slack</Option>
+ * </Checkboxes>
+ * ```
+ */
 export default class Checkboxes {
   static slackType = 'Checkboxes';
   declare props: Props;

--- a/src/components/input/date-picker.tsx
+++ b/src/components/input/date-picker.tsx
@@ -7,6 +7,18 @@ export type Props = {
   focusOnLoad?: boolean;
 };
 
+/**
+ * A date picker — a calendar-style date selector.
+ *
+ * `initialDate` must be in `YYYY-MM-DD` format.
+ *
+ * @example
+ * ```tsx
+ * <Input label="Due date" element={
+ *   <DatePicker actionId="due_date" initialDate="2024-12-31" />
+ * } />
+ * ```
+ */
 export default class DatePicker {
   static slackType = 'DatePicker';
   declare props: Props;

--- a/src/components/input/date-time-picker.tsx
+++ b/src/components/input/date-time-picker.tsx
@@ -6,6 +6,18 @@ export type Props = {
   focusOnLoad?: boolean;
 };
 
+/**
+ * A combined date and time picker.
+ *
+ * `initialDateTime` is a Unix timestamp (seconds since epoch).
+ *
+ * @example
+ * ```tsx
+ * <Input label="Scheduled at" element={
+ *   <DateTimePicker actionId="scheduled_at" initialDateTime={1700000000} />
+ * } />
+ * ```
+ */
 export default class DateTimePicker {
   static slackType = 'DateTimePicker';
   declare props: Props;

--- a/src/components/input/option-group.tsx
+++ b/src/components/input/option-group.tsx
@@ -4,6 +4,18 @@ export type Props = {
   children: JSX.Element | JSX.Element[];
 };
 
+/**
+ * Groups options under a labeled heading inside a `<Select>`.
+ *
+ * @example
+ * ```tsx
+ * <Select placeholder="Pick one" actionId="grouped">
+ *   <OptionGroup label="Fruits">
+ *     <Option value="apple">Apple</Option>
+ *   </OptionGroup>
+ * </Select>
+ * ```
+ */
 export default class OptionGroup {
   static slackType = 'OptionGroup';
   declare props: Props;

--- a/src/components/input/option.tsx
+++ b/src/components/input/option.tsx
@@ -6,6 +6,16 @@ export type Props = {
   description?: string;
 };
 
+/**
+ * An option item for `<Select>`, `<Checkboxes>`, `<RadioGroup>`, or `<Overflow>`.
+ *
+ * The children (text) is the display label; `value` is sent in the action payload.
+ *
+ * @example
+ * ```tsx
+ * <Option value="opt_a" description="The first option">Option A</Option>
+ * ```
+ */
 export default class Option {
   static slackType = 'Option';
   declare props: Props;

--- a/src/components/input/overflow.tsx
+++ b/src/components/input/overflow.tsx
@@ -7,6 +7,20 @@ export type Props = {
   confirm?: JSX.Element;
 };
 
+/**
+ * An overflow menu — the "⋯" button that reveals a list of options.
+ *
+ * Requires at least 2 `<Option>` children. Options can include a `url` to open a link.
+ *
+ * @example
+ * ```tsx
+ * <Overflow actionId="more">
+ *   <Option value="edit">Edit</Option>
+ *   <Option value="delete">Delete</Option>
+ *   <Option value="docs" url="https://example.com/docs">View docs</Option>
+ * </Overflow>
+ * ```
+ */
 export default class Overflow {
   static slackType = 'Overflow';
   declare props: Props;

--- a/src/components/input/radio-group.tsx
+++ b/src/components/input/radio-group.tsx
@@ -9,6 +9,20 @@ export type Props = {
   focusOnLoad?: boolean;
 };
 
+/**
+ * A radio button group — allows exactly one selection from a list of options.
+ *
+ * Pass `<Option>` elements as children. Pre-select an option via `initialOption`.
+ *
+ * @example
+ * ```tsx
+ * <RadioGroup actionId="size" initialOption={<Option value="m">Medium</Option>}>
+ *   <Option value="s">Small</Option>
+ *   <Option value="m">Medium</Option>
+ *   <Option value="l">Large</Option>
+ * </RadioGroup>
+ * ```
+ */
 export default class RadioGroup {
   static slackType = 'RadioGroup';
   declare props: Props;

--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -36,6 +36,25 @@ export type Props = {
   filter?: ConversationFilter;
 };
 
+/**
+ * A select menu — supports static options, external data sources, and user /
+ * channel / conversation lists. Can be single or multi-select.
+ *
+ * Use the `type` prop to switch data sources (default: `'static'`).
+ * Pass `<Option>` or `<OptionGroup>` children for static selects.
+ *
+ * @example
+ * ```tsx
+ * // Static single-select
+ * <Select placeholder="Pick one" actionId="color">
+ *   <Option value="red">Red</Option>
+ *   <Option value="blue">Blue</Option>
+ * </Select>
+ *
+ * // User multi-select
+ * <Select type="user" multi placeholder="Pick users" actionId="mentions" />
+ * ```
+ */
 export default class Select {
   static slackType = 'Select';
   declare props: Props;

--- a/src/components/input/text.tsx
+++ b/src/components/input/text.tsx
@@ -12,6 +12,21 @@ export type Props = {
   };
 };
 
+/**
+ * A plain-text input field — used as the `element` prop inside `<Input>`.
+ *
+ * @example
+ * ```tsx
+ * <Input label="Your name" element={
+ *   <TextInput
+ *     actionId="name"
+ *     placeholder="Jane Doe"
+ *     maxLength={80}
+ *     focusOnLoad
+ *   />
+ * } />
+ * ```
+ */
 export default class TextInput {
   static slackType = 'TextInput';
   declare props: Props;

--- a/src/components/input/time-picker.tsx
+++ b/src/components/input/time-picker.tsx
@@ -7,6 +7,18 @@ export type Props = {
   focusOnLoad?: boolean;
 };
 
+/**
+ * A time picker — a clock-style time selector.
+ *
+ * `initialTime` must be in `HH:mm` (24-hour) format.
+ *
+ * @example
+ * ```tsx
+ * <Input label="Meeting time" element={
+ *   <TimePicker actionId="meeting_time" initialTime="09:00" />
+ * } />
+ * ```
+ */
 export default class TimePicker {
   static slackType = 'TimePicker';
   declare props: Props;

--- a/src/components/layout/actions.tsx
+++ b/src/components/layout/actions.tsx
@@ -6,6 +6,20 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * An actions block — displays interactive elements in a horizontal row.
+ *
+ * Accepts up to 25 interactive elements as children: `<Button>`, `<Select>`,
+ * `<Overflow>`, `<DatePicker>`, `<TimePicker>`, `<DateTimePicker>`.
+ *
+ * @example
+ * ```tsx
+ * <Actions>
+ *   <Button actionId="approve" style="primary">Approve</Button>
+ *   <Button actionId="deny" style="danger">Deny</Button>
+ * </Actions>
+ * ```
+ */
 export default class Actions {
   static slackType = 'Actions';
   declare props: Props;

--- a/src/components/layout/container.tsx
+++ b/src/components/layout/container.tsx
@@ -6,6 +6,23 @@ export type Props = {
   children: SingleOrArray<Child>;
 };
 
+/**
+ * A pass-through utility component that renders its children without adding
+ * any wrapper block. Useful for conditional rendering and mapping arrays
+ * without introducing an extra layout layer.
+ *
+ * @example
+ * ```tsx
+ * <Message text="Hello">
+ *   {isAdmin && (
+ *     <Container>
+ *       <Section text={<Text>Admin section</Text>} />
+ *       <Divider />
+ *     </Container>
+ *   )}
+ * </Message>
+ * ```
+ */
 export default class Container {
   static slackType = 'Container';
   declare props: Props;

--- a/src/components/layout/context.tsx
+++ b/src/components/layout/context.tsx
@@ -6,6 +6,19 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * A context block — displays small text and images in a horizontal row.
+ *
+ * Accepts up to 10 `<Text>` or `<Image>` elements as children.
+ *
+ * @example
+ * ```tsx
+ * <Context>
+ *   <Image url="https://example.com/avatar.png" alt="avatar" />
+ *   <Text>Posted by *Jane Doe*</Text>
+ * </Context>
+ * ```
+ */
 export default class Context {
   static slackType = 'Context';
   declare props: Props;

--- a/src/components/layout/divider.tsx
+++ b/src/components/layout/divider.tsx
@@ -3,6 +3,14 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * A divider block — renders a horizontal rule between blocks.
+ *
+ * @example
+ * ```tsx
+ * <Divider />
+ * ```
+ */
 export default class Divider {
   static slackType = 'Divider';
   declare props: Props;

--- a/src/components/layout/file.tsx
+++ b/src/components/layout/file.tsx
@@ -4,6 +4,14 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * A file block — embeds a remote file that has been shared in Slack.
+ *
+ * @example
+ * ```tsx
+ * <File externalId="my-report-id" />
+ * ```
+ */
 export default class File {
   static slackType = 'File';
   declare props: Props;

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,6 +5,16 @@ export type Props = {
   emoji?: boolean;
 };
 
+/**
+ * A header block — displays large, bold plain text at the top of a section.
+ *
+ * Maximum 150 characters.
+ *
+ * @example
+ * ```tsx
+ * <Header text="Deploy complete" emoji />
+ * ```
+ */
 export default class Header {
   static slackType = 'Header';
   declare props: Props;

--- a/src/components/layout/image.tsx
+++ b/src/components/layout/image.tsx
@@ -6,6 +6,22 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * An image layout block — displays a full-width image.
+ *
+ * Imported as `ImageLayout` to avoid ambiguity with the `<Image>` element.
+ *
+ * @example
+ * ```tsx
+ * import { ImageLayout } from 'slackblock/block';
+ *
+ * <ImageLayout
+ *   url="https://example.com/chart.png"
+ *   alt="Sales chart"
+ *   title="Q4 Results"
+ * />
+ * ```
+ */
 export default class Image {
   static slackType = 'ImageLayout';
   declare props: Props;

--- a/src/components/layout/input.tsx
+++ b/src/components/layout/input.tsx
@@ -9,6 +9,20 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * An input block — wraps a single interactive input element with a label.
+ *
+ * Pass the input element via the `element` prop (not as a child).
+ *
+ * @example
+ * ```tsx
+ * <Input
+ *   label="Your name"
+ *   hint="Use your full name"
+ *   element={<TextInput actionId="name" placeholder="Jane Doe" />}
+ * />
+ * ```
+ */
 export default class Input {
   static slackType = 'Input';
   declare props: Props;

--- a/src/components/layout/rich-text.tsx
+++ b/src/components/layout/rich-text.tsx
@@ -9,6 +9,22 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * A rich text block — contains formatted text with inline styling, lists,
+ * quotes, and preformatted code.
+ *
+ * Accepts `<RichTextSection>`, `<RichTextList>`, `<RichTextQuote>`, and
+ * `<RichTextPreformatted>` as children.
+ *
+ * @example
+ * ```tsx
+ * <RichText>
+ *   <RichTextSection>
+ *     <RichTextText style={{ bold: true }}>Hello</RichTextText>
+ *   </RichTextSection>
+ * </RichText>
+ * ```
+ */
 export default class RichText {
   static slackType = 'RichText';
   declare props: Props;

--- a/src/components/layout/section.tsx
+++ b/src/components/layout/section.tsx
@@ -12,6 +12,23 @@ export type Props = {
   accessory?: BlockElement;
 };
 
+/**
+ * A section block — the most versatile layout block.
+ *
+ * Displays a primary text label, optional two-column fields (children),
+ * and an optional accessory element on the right.
+ *
+ * @example
+ * ```tsx
+ * <Section
+ *   text={<Text>Hello *world*</Text>}
+ *   accessory={<Button actionId="more">More</Button>}
+ * >
+ *   <Text plainText>Field A</Text>
+ *   <Text plainText>Field B</Text>
+ * </Section>
+ * ```
+ */
 export default class Section {
   static slackType = 'Section';
   declare props: Props;

--- a/src/components/layout/video.tsx
+++ b/src/components/layout/video.tsx
@@ -12,6 +12,20 @@ export type Props = {
   blockId?: string;
 };
 
+/**
+ * A video block — embeds an external video with a thumbnail, title, and metadata.
+ *
+ * @example
+ * ```tsx
+ * <Video
+ *   title="Product Demo"
+ *   videoUrl="https://example.com/demo.mp4"
+ *   thumbnailUrl="https://example.com/thumb.png"
+ *   altText="Product demo video"
+ *   authorName="Product Team"
+ * />
+ * ```
+ */
 export default class Video {
   static slackType = 'Video';
   declare props: Props;

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -1,6 +1,12 @@
 
 import {type Child} from '../constants/types';
 
+/**
+ * Props for the `<Message>` component.
+ *
+ * The top-level element required by `render()` / `renderToMessage()`.
+ * Add blocks as children; use `text` as a fallback for notifications.
+ */
 export type Properties = {
   children: Child;
   text?: string;
@@ -17,6 +23,21 @@ export type Properties = {
   color?: string;
 };
 
+/**
+ * Root element for a Slack chat message.
+ *
+ * Must be the top-level element passed to `render()`.
+ * Add layout blocks as children.
+ *
+ * @example
+ * ```tsx
+ * render(
+ *   <Message text="Fallback">
+ *     <Header text="Hello" />
+ *   </Message>
+ * );
+ * ```
+ */
 export default class Message {
   static slackType = 'Message';
   declare props: Properties;

--- a/src/components/rich-text/broadcast.tsx
+++ b/src/components/rich-text/broadcast.tsx
@@ -5,6 +5,14 @@ export type Props = {
   range: RichTextBroadcastRange;
 };
 
+/**
+ * A `@here`, `@channel`, or `@everyone` broadcast mention in rich text.
+ *
+ * @example
+ * ```tsx
+ * <RichTextBroadcast range="here" />
+ * ```
+ */
 export default class RichTextBroadcast {
   static slackType = 'RichTextBroadcast';
   declare props: Props;

--- a/src/components/rich-text/channel.tsx
+++ b/src/components/rich-text/channel.tsx
@@ -3,6 +3,14 @@ export type Props = {
   channelId: string;
 };
 
+/**
+ * Mentions a Slack channel by ID in rich text (renders as `#channel-name`).
+ *
+ * @example
+ * ```tsx
+ * <RichTextChannel channelId="C123456" />
+ * ```
+ */
 export default class RichTextChannel {
   static slackType = 'RichTextChannel';
   declare props: Props;

--- a/src/components/rich-text/date.tsx
+++ b/src/components/rich-text/date.tsx
@@ -5,6 +5,23 @@ export type Props = {
   fallback: string;
 };
 
+/**
+ * Renders a formatted date that adapts to each viewer's local timezone.
+ *
+ * `timestamp` is a Unix timestamp. `format` uses Slack's date format tokens
+ * (e.g. `"{date_long} at {time}"`). `fallback` is shown if rendering fails.
+ *
+ * @see https://api.slack.com/reference/surfaces/formatting#date-formatting
+ *
+ * @example
+ * ```tsx
+ * <RichTextDate
+ *   timestamp={1700000000}
+ *   format="{date_long} at {time}"
+ *   fallback="Nov 14, 2023 at 22:13"
+ * />
+ * ```
+ */
 export default class RichTextDate {
   static slackType = 'RichTextDate';
   declare props: Props;

--- a/src/components/rich-text/emoji.tsx
+++ b/src/components/rich-text/emoji.tsx
@@ -3,6 +3,14 @@ export type Props = {
   name: string;
 };
 
+/**
+ * Renders an emoji by name in rich text.
+ *
+ * @example
+ * ```tsx
+ * <RichTextEmoji name="wave" />
+ * ```
+ */
 export default class RichTextEmoji {
   static slackType = 'RichTextEmoji';
   declare props: Props;

--- a/src/components/rich-text/link.tsx
+++ b/src/components/rich-text/link.tsx
@@ -7,6 +7,15 @@ export type Props = {
   style?: RichTextStyle;
 };
 
+/**
+ * A hyperlink within rich text. Displays `children` as the link text,
+ * or falls back to the URL if `children` is omitted.
+ *
+ * @example
+ * ```tsx
+ * <RichTextLink url="https://example.com" style={{ bold: true }}>Visit us</RichTextLink>
+ * ```
+ */
 export default class RichTextLink {
   static slackType = 'RichTextLink';
   declare props: Props;

--- a/src/components/rich-text/list.tsx
+++ b/src/components/rich-text/list.tsx
@@ -10,6 +10,20 @@ export type Props = {
   border?: number;
 };
 
+/**
+ * A bulleted or numbered list in rich text.
+ *
+ * Each list item should be a `<RichTextSection>` child.
+ * Supports indentation (`indent` 0–6) and border styling.
+ *
+ * @example
+ * ```tsx
+ * <RichTextList style="bullet" indent={1}>
+ *   <RichTextSection><RichTextText>Item one</RichTextText></RichTextSection>
+ *   <RichTextSection><RichTextText>Item two</RichTextText></RichTextSection>
+ * </RichTextList>
+ * ```
+ */
 export default class RichTextList {
   static slackType = 'RichTextList';
   declare props: Props;

--- a/src/components/rich-text/preformatted.tsx
+++ b/src/components/rich-text/preformatted.tsx
@@ -5,6 +5,16 @@ export type Props = {
   children: SingleOrArray<JSX.Element | string>;
 };
 
+/**
+ * A preformatted code block in rich text — monospaced, no line wrapping.
+ *
+ * @example
+ * ```tsx
+ * <RichTextPreformatted>
+ *   <RichTextText style={{ code: true }}>const x = 1;</RichTextText>
+ * </RichTextPreformatted>
+ * ```
+ */
 export default class RichTextPreformatted {
   static slackType = 'RichTextPreformatted';
   declare props: Props;

--- a/src/components/rich-text/quote.tsx
+++ b/src/components/rich-text/quote.tsx
@@ -5,6 +5,16 @@ export type Props = {
   children: SingleOrArray<JSX.Element | string>;
 };
 
+/**
+ * A blockquote in rich text — displays content with a visual left-border indent.
+ *
+ * @example
+ * ```tsx
+ * <RichTextQuote>
+ *   <RichTextText>This is a quoted passage.</RichTextText>
+ * </RichTextQuote>
+ * ```
+ */
 export default class RichTextQuote {
   static slackType = 'RichTextQuote';
   declare props: Props;

--- a/src/components/rich-text/section.tsx
+++ b/src/components/rich-text/section.tsx
@@ -5,6 +5,18 @@ export type Props = {
   children: SingleOrArray<JSX.Element | string>;
 };
 
+/**
+ * An inline container for rich text content within a `<RichText>` block.
+ * Also used as individual list items inside `<RichTextList>`.
+ *
+ * @example
+ * ```tsx
+ * <RichTextSection>
+ *   <RichTextText style={{ bold: true }}>Hello</RichTextText>
+ *   {' world'}
+ * </RichTextSection>
+ * ```
+ */
 export default class RichTextSection {
   static slackType = 'RichTextSection';
   declare props: Props;

--- a/src/components/rich-text/text.tsx
+++ b/src/components/rich-text/text.tsx
@@ -6,6 +6,17 @@ export type Props = {
   style?: RichTextStyle;
 };
 
+/**
+ * Styled text within a rich text block.
+ *
+ * Apply bold, italic, strikethrough, or inline code styling via `style`.
+ *
+ * @example
+ * ```tsx
+ * <RichTextText style={{ bold: true, italic: true }}>Bold italic</RichTextText>
+ * <RichTextText style={{ code: true }}>inline code</RichTextText>
+ * ```
+ */
 export default class RichTextText {
   static slackType = 'RichTextText';
   declare props: Props;

--- a/src/components/rich-text/user-group.tsx
+++ b/src/components/rich-text/user-group.tsx
@@ -3,6 +3,14 @@ export type Props = {
   usergroupId: string;
 };
 
+/**
+ * Mentions a Slack user group by ID in rich text.
+ *
+ * @example
+ * ```tsx
+ * <RichTextUserGroup usergroupId="S123456" />
+ * ```
+ */
 export default class RichTextUserGroup {
   static slackType = 'RichTextUserGroup';
   declare props: Props;

--- a/src/components/rich-text/user.tsx
+++ b/src/components/rich-text/user.tsx
@@ -3,6 +3,14 @@ export type Props = {
   userId: string;
 };
 
+/**
+ * Mentions a Slack user by ID in rich text (renders as `@username`).
+ *
+ * @example
+ * ```tsx
+ * <RichTextUser userId="U123456" />
+ * ```
+ */
 export default class RichTextUser {
   static slackType = 'RichTextUser';
   declare props: Props;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,22 @@
+/**
+ * Error thrown by `render()` / `renderToBlocks()` when `validate: 'strict'`
+ * is set and a validation rule is violated.
+ *
+ * @example
+ * ```ts
+ * import { SlackblockValidationError } from 'slackblock';
+ *
+ * try {
+ *   render(<Message>...</Message>, { validate: 'strict' });
+ * } catch (err) {
+ *   if (err instanceof SlackblockValidationError) {
+ *     console.error(err.message); // "Message > Header: Header text exceeds 150 characters."
+ *     console.error(err.path);    // "Message > Header"
+ *     console.error(err.rule);    // "too-long"
+ *   }
+ * }
+ * ```
+ */
 export class SlackblockValidationError extends Error {
   readonly path: string;
   readonly rule: string;

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -10,6 +10,14 @@ import {
 } from '../utils/validation-context';
 import {MAX_BLOCKS, MAX_MESSAGE_TEXT, RECOMMENDED_MESSAGE_TEXT} from '../constants/limits';
 
+/**
+ * Options passed to `render()`, `renderToMessage()`, and `renderToBlocks()`.
+ *
+ * @property validate - Validation mode. Defaults to `'warn'`.
+ *   - `'warn'`   — log warnings via `console.warn` (default)
+ *   - `'strict'` — throw `SlackblockValidationError` on any violation
+ *   - `'off'`    — disable validation entirely
+ */
 export type RenderOptions = {validate?: ValidationMode};
 
 /**
@@ -65,6 +73,26 @@ const applyMessageMetadata = (json: SlackMessageDraft, properties: MessageProper
   }
 };
 
+/**
+ * Renders a `<Message>` JSX tree to a full Slack message payload.
+ *
+ * The result is a plain object ready to spread into `chat.postMessage`.
+ * The top-level element must be a `<Message>` — a `TypeError` is thrown otherwise.
+ *
+ * @example
+ * ```tsx
+ * import render from 'slackblock';
+ * import { Message, Header } from 'slackblock/block';
+ *
+ * const message = render(
+ *   <Message text="Hello">
+ *     <Header text="Hello world" />
+ *   </Message>
+ * );
+ *
+ * await slackClient.chat.postMessage({ channel: '#general', ...message });
+ * ```
+ */
 const render = (element: Element, options?: RenderOptions): SlackMessage => {
   initContext(options?.validate ?? 'warn');
 

--- a/src/utils/escape-mrkdwn.ts
+++ b/src/utils/escape-mrkdwn.ts
@@ -1,3 +1,17 @@
+/**
+ * Escapes Slack mrkdwn special characters in a string to prevent unintended
+ * formatting. Use this when inserting untrusted user content into mrkdwn fields.
+ *
+ * Escapes: `&` `<` `>` `*` `_` `~` `` ` ``
+ *
+ * @example
+ * ```ts
+ * import { escapeMrkdwn } from 'slackblock';
+ *
+ * const safe = escapeMrkdwn('Hello *world* <script>');
+ * // → "Hello \u200B*world\u200B* &lt;script&gt;"
+ * ```
+ */
 export const escapeMrkdwn = (text: string): string =>
   text
     .replaceAll('&', '&amp;')

--- a/src/utils/validation-context.ts
+++ b/src/utils/validation-context.ts
@@ -1,5 +1,12 @@
 import {SlackblockValidationError} from '../errors';
 
+/**
+ * Controls how SlackBlock handles validation violations during rendering.
+ *
+ * - `'warn'`   — emit `console.warn` messages (default)
+ * - `'strict'` — throw `SlackblockValidationError`
+ * - `'off'`    — suppress all validation
+ */
 export type ValidationMode = 'off' | 'warn' | 'strict';
 
 type ValidationContext = {


### PR DESCRIPTION
## Summary

- **README rewrite** — quick start, TypeScript setup (`jsxImportSource`), full API reference (render, renderToBlocks, renderToMessage, blockKitBuilderUrl, escapeMrkdwn), validation mode overview, component list, links to docs/
- **`docs/components.md`** — props tables and usage examples for all 40+ public components (layout blocks, block elements, input elements, rich text elements)
- **`docs/validation.md`** — validation modes, all rules with limit tables, `SlackblockValidationError` fields, testing patterns with strict mode
- **`docs/migrating-from-jsx-slack.md`** — conceptual mapping, corrected for jsx-slack's own JSX runtime, `<Field>` fields, `<Confirm>` naming
- **`docs/migrating-from-slack-block-builder.md`** — builder-to-JSX mapping, corrected select/radio/overflow/confirmation class names
- **JSDoc** — added to all 40+ component classes, `render()`, `renderToBlocks`, `RenderOptions`, `ValidationMode`, `SlackblockValidationError`, `escapeMrkdwn`
- **UPGRADE_PLAN.md** — Phase F marked substantially complete

## Test plan

- [ ] `pnpm run test:tsc` passes (no type errors introduced by JSDoc)
- [ ] `pnpm run test:lint` passes
- [ ] README renders correctly on GitHub (check badges, code blocks, tables)
- [ ] Hover over a component in an IDE to verify JSDoc tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)