### PR TITLE
Stabilize validation error contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ try {
   if (err instanceof SlackblockValidationError) {
     console.error(err.message); // "Message > Header: Header text exceeds 150 characters."
     console.error(err.path);    // "Message > Header"
-    console.error(err.rule);    // "value-too-long"
+    console.error(err.rule);    // "too-long"
+    console.error(err.subcode); // "value-too-long"
   }
 }
 ```
@@ -200,7 +201,7 @@ Strict mode now catches missing required props and structural gaps across the su
 - incomplete `<Confirmation>` dialogs
 - `<Section>` blocks with neither primary text nor fields
 
-See [docs/validation.md](docs/validation.md) for the current runtime rule reference.
+See [docs/validation.md](docs/validation.md) for the stable rule categories and current subcodes.
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -42,7 +42,11 @@ import { SlackblockValidationError } from 'slackblock';
 |-------|------|-------------|
 | `message` | `string` | Full error message including path (e.g. `"Message > Header: Header text exceeds 150 characters."`) |
 | `path` | `string` | Component path at the point of failure (e.g. `"Message > Header"`) |
-| `rule` | `string` | Rule identifier (see table below) |
+| `rule` | `ValidationRule` | Stable rule category |
+| `subcode` | `string \| undefined` | Optional machine-readable detail |
+| `component` | `string \| undefined` | Component that triggered the issue |
+| `field` | `string \| undefined` | Field associated with the issue when applicable |
+| `issue` | `ValidationIssue` | Full normalized issue object |
 
 ### Example
 
@@ -63,6 +67,9 @@ try {
     // → "Message > Header"
 
     console.error(err.rule);
+    // → "too-long"
+
+    console.error(err.subcode);
     // → "value-too-long"
   }
 }
@@ -70,15 +77,15 @@ try {
 
 ---
 
-## Current Rule Strings
+## Rule Categories
 
-SlackBlock currently emits granular `error.rule` values. The public contract is not normalized yet, so the exact string depends on the failing field.
+SlackBlock now emits stable top-level `rule` categories. When you need detail, inspect `subcode`.
 
-### Required-field rules
+### `required-field`
 
 Triggered when a required prop is missing.
 
-Examples:
+Example subcodes:
 - `action-id-required`
 - `external-id-required`
 - `label-required`
@@ -91,31 +98,19 @@ Examples:
 - `alt-required`
 - `options-required`
 - `elements-required`
-- `text-or-fields-required`
-
-Common components now covered:
-- `Button`: `actionId`, text
-- `TextInput`: `actionId`
-- `Overflow`: `actionId`, options
-- `File`: `externalId`
-- `Image` / `ImageLayout`: `url`, `alt`
-- `Input`: `label`, `element`
-- `Confirmation`: `title`, `confirm`, `deny`, body text
-- `Section`: `text` or field children
-- `Checkboxes`: `actionId`, options
-- `RadioGroup`: `actionId`, options
-- `Select`: `actionId`, `placeholder`, and static-select options
 
 ```tsx
 <Button>Submit</Button>
-// rule: "action-id-required"
+// rule: "required-field"
+// subcode: "action-id-required"
 ```
 
-### Length rules
+### `too-long`
 
 Triggered when a string prop exceeds Slack's documented character limit.
 
-Runtime rule: `value-too-long`
+Current subcode:
+- `value-too-long`
 
 | Component / Prop | Limit |
 |------------------|-------|
@@ -147,11 +142,12 @@ Runtime rule: `value-too-long`
 | `actionId` | 255 chars |
 | `placeholder` | 150 chars |
 
-### Count rules
+### `too-many`
 
 Triggered when a collection exceeds Slack's documented count limit.
 
-Runtime rule: `too-many-items`
+Current subcode:
+- `too-many-items`
 
 | Component / Collection | Limit |
 |------------------------|-------|
@@ -166,11 +162,11 @@ Runtime rule: `too-many-items`
 | `Select` option groups | 100 |
 | `OptionGroup` options | 100 |
 
-### Format rules
+### `invalid-format`
 
 Triggered when a date or time prop does not match the required format.
 
-Runtime rules:
+Current subcodes:
 - `invalid-date-format`
 - `invalid-time-format`
 
@@ -179,18 +175,37 @@ Runtime rules:
 | `DatePicker.initialDate` | `YYYY-MM-DD` |
 | `TimePicker.initialTime` | `HH:mm` (24-hour) |
 
-### Structural rules
+### `invalid-structure`
 
 Triggered when a supported component is missing one of several acceptable alternatives.
 
-Runtime rules:
+Current subcodes:
 - `text-or-fields-required`
 
-### Unknown transformer rule
+### `unsupported-child`
 
-Runtime rule: `unknown-type`
+Triggered when a component is not recognized by SlackBlock's transformer registry.
 
-Triggered when a component is not recognized by SlackBlock's transformer registry. Unrecognized components are silently dropped from the output unless validation is strict.
+Current subcode:
+- `unknown-type`
+
+Unrecognized components are silently dropped from the output unless validation is strict.
+
+---
+
+## Migration Notes
+
+If you previously matched against the old granular `error.rule` strings, switch to the stable category in `rule` and use `subcode` for the old detail.
+
+Examples:
+
+| Before | After |
+|---|---|
+| `error.rule === "action-id-required"` | `error.rule === "required-field" && error.subcode === "action-id-required"` |
+| `error.rule === "value-too-long"` | `error.rule === "too-long" && error.subcode === "value-too-long"` |
+| `error.rule === "too-many-items"` | `error.rule === "too-many" && error.subcode === "too-many-items"` |
+| `error.rule === "invalid-date-format"` | `error.rule === "invalid-format" && error.subcode === "invalid-date-format"` |
+| `error.rule === "unknown-type"` | `error.rule === "unsupported-child" && error.subcode === "unknown-type"` |
 
 ---
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,22 @@
+export type ValidationRule =
+  | 'required-field'
+  | 'too-long'
+  | 'too-many'
+  | 'invalid-format'
+  | 'invalid-value'
+  | 'invalid-structure'
+  | 'unsupported-prop'
+  | 'unsupported-child';
+
+export type ValidationIssue = {
+  rule: ValidationRule;
+  subcode?: string;
+  message: string;
+  path: string;
+  component?: string;
+  field?: string;
+};
+
 /**
  * Error thrown by `render()` / `renderToBlocks()` when `validate: 'strict'`
  * is set and a validation rule is violated.
@@ -13,17 +32,27 @@
  *     console.error(err.message); // "Message > Header: Header text exceeds 150 characters."
  *     console.error(err.path);    // "Message > Header"
  *     console.error(err.rule);    // "too-long"
+ *     console.error(err.subcode); // "value-too-long"
  *   }
  * }
  * ```
  */
 export class SlackblockValidationError extends Error {
   readonly path: string;
-  readonly rule: string;
-  constructor(message: string, path: string, rule: string) {
-    super(`${path}: ${message}`);
+  readonly rule: ValidationRule;
+  readonly subcode?: string;
+  readonly component?: string;
+  readonly field?: string;
+  readonly issue: ValidationIssue;
+
+  constructor(issue: ValidationIssue) {
+    super(`${issue.path}: ${issue.message}`);
     this.name = 'SlackblockValidationError';
-    this.path = path;
-    this.rule = rule;
+    this.path = issue.path;
+    this.rule = issue.rule;
+    this.subcode = issue.subcode;
+    this.component = issue.component;
+    this.field = issue.field;
+    this.issue = issue;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ export {
   type SerializedOption,
 } from './constants/types';
 export {type ValidationMode} from './utils/validation-context';
-export {SlackblockValidationError} from './errors';
+export {
+  SlackblockValidationError,
+  type ValidationIssue,
+  type ValidationRule,
+} from './errors';
 export {escapeMrkdwn} from './utils/escape-mrkdwn';
 export {blockKitBuilderUrl} from './utils/block-kit-builder';

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -43,7 +43,12 @@ const parseChildren = (children: Child): ParsedMessage => {
         popPath();
       }
     } else if (type !== 'null') {
-      report(`No transformer for component type '${type}'.`, 'unknown-type');
+      report({
+        message: `No transformer for component type '${type}'.`,
+        rule: 'unsupported-child',
+        subcode: 'unknown-type',
+        component: type,
+      });
     }
   }
 

--- a/src/transformers/input/date-picker.tsx
+++ b/src/transformers/input/date-picker.tsx
@@ -58,7 +58,12 @@ const transformDatePicker = (child: Element): DatePickerType => {
 
   if (initialDate) {
     if (!isValidDateString(initialDate)) {
-      report('Date must be valid and in format YYYY-MM-DD.', 'invalid-date-format');
+      report({
+        message: 'Date must be valid and in format YYYY-MM-DD.',
+        rule: 'invalid-format',
+        subcode: 'invalid-date-format',
+        field: 'initialDate',
+      });
     }
 
     res.initial_date = initialDate;

--- a/src/transformers/input/time-picker.tsx
+++ b/src/transformers/input/time-picker.tsx
@@ -50,7 +50,12 @@ const transformTimePicker = (child: Element): TimePickerType => {
 
   if (initialTime) {
     if (!isValidTimeString(initialTime)) {
-      report('Time must be valid and in format HH:MM.', 'invalid-time-format');
+      report({
+        message: 'Time must be valid and in format HH:MM.',
+        rule: 'invalid-format',
+        subcode: 'invalid-time-format',
+        field: 'initialTime',
+      });
     }
 
     res.initial_time = initialTime;

--- a/src/transformers/transform.ts
+++ b/src/transformers/transform.ts
@@ -8,7 +8,12 @@ export const transform = (element: Element): unknown => {
   const type = getType(element);
 
   if (!Transformers[type]) {
-    report(`No transformer for component type '${type}'.`, 'unknown-type');
+    report({
+      message: `No transformer for component type '${type}'.`,
+      rule: 'unsupported-child',
+      subcode: 'unknown-type',
+      component: type,
+    });
     return {};
   }
 

--- a/src/utils/validation-context.ts
+++ b/src/utils/validation-context.ts
@@ -1,4 +1,4 @@
-import {SlackblockValidationError} from '../errors';
+import {SlackblockValidationError, type ValidationIssue, type ValidationRule} from '../errors';
 
 /**
  * Controls how SlackBlock handles validation violations during rendering.
@@ -34,17 +34,43 @@ export const popPath = (): void => {
 
 const getPath = (): string => context.path.join(' > ');
 
-export const report = (message: string, rule: string): void => {
+type ReportInput = {
+  message: string;
+  rule: ValidationRule;
+  subcode?: string;
+  component?: string;
+  field?: string;
+};
+
+const getCurrentComponent = (): string | undefined => {
+  for (let index = context.path.length - 1; index >= 0; index--) {
+    const segment = context.path[index];
+
+    if (segment !== 'Message') {
+      return segment;
+    }
+  }
+
+  return context.path.at(-1);
+};
+
+const toIssue = (input: ReportInput): ValidationIssue => ({
+  ...input,
+  path: getPath(),
+  component: input.component ?? getCurrentComponent(),
+});
+
+export const report = (input: ReportInput): void => {
   if (context.mode === 'off') {
     return;
   }
 
-  const path = getPath();
+  const issue = toIssue(input);
 
   if (context.mode === 'warn') {
-    console.warn(`[slackblock] ${path}: ${message}`);
+    console.warn(`[slackblock] ${issue.path}: ${issue.message}`);
     return;
   }
 
-  throw new SlackblockValidationError(message, path, rule);
+  throw new SlackblockValidationError(issue);
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -23,7 +23,11 @@ export const warnIfTooLong = (name: string, value: string | undefined, max: numb
   }
 
   if (value.length > max) {
-    report(`${name} exceeds ${max} characters.`, 'value-too-long');
+    report({
+      message: `${name} exceeds ${max} characters.`,
+      rule: 'too-long',
+      subcode: 'value-too-long',
+    });
   }
 };
 
@@ -33,13 +37,22 @@ export const warnIfTooMany = (name: string, values: unknown[] | undefined, max: 
   }
 
   if (values.length > max) {
-    report(`${name} exceeds ${max} items.`, 'too-many-items');
+    report({
+      message: `${name} exceeds ${max} items.`,
+      rule: 'too-many',
+      subcode: 'too-many-items',
+    });
   }
 };
 
 export const requireField = (fieldName: string, value: unknown): void => {
   if (isMissing(value)) {
-    report(`${fieldName} is required.`, `${toKebab(fieldName)}-required`);
+    report({
+      message: `${fieldName} is required.`,
+      rule: 'required-field',
+      subcode: `${toKebab(fieldName)}-required`,
+      field: fieldName,
+    });
   }
 };
 
@@ -48,5 +61,9 @@ export const requireOneOf = (fieldNames: string[], values: unknown[]): void => {
     return;
   }
 
-  report(`At least one of ${fieldNames.join(' or ')} is required.`, `${fieldNames.map(fieldName => toKebab(fieldName)).join('-or-')}-required`);
+  report({
+    message: `At least one of ${fieldNames.join(' or ')} is required.`,
+    rule: 'invalid-structure',
+    subcode: `${fieldNames.map(fieldName => toKebab(fieldName)).join('-or-')}-required`,
+  });
 };

--- a/test/validation/validation.test.tsx
+++ b/test/validation/validation.test.tsx
@@ -223,7 +223,7 @@ describe('strict mode', () => {
       )).toThrow(SlackblockValidationError);
   });
 
-  test('error.rule is correct for length violation', () => {
+  test('error.rule is normalized for length violation', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -240,10 +240,11 @@ describe('strict mode', () => {
     }
 
     expect(error_).toBeInstanceOf(SlackblockValidationError);
-    expect(error_?.rule).toBe('value-too-long');
+    expect(error_?.rule).toBe('too-long');
+    expect(error_?.subcode).toBe('value-too-long');
   });
 
-  test('error.rule is correct for count violation', () => {
+  test('error.rule is normalized for count violation', () => {
     const manyButtons = Array.from({length: 30}, (_, index) => (
       <Button actionId={`btn-${index}`}>Click</Button>
     ));
@@ -262,10 +263,11 @@ describe('strict mode', () => {
       }
     }
 
-    expect(error_?.rule).toBe('too-many-items');
+    expect(error_?.rule).toBe('too-many');
+    expect(error_?.subcode).toBe('too-many-items');
   });
 
-  test('error.rule is correct for invalid date format', () => {
+  test('error.rule is normalized for invalid date format', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -283,10 +285,12 @@ describe('strict mode', () => {
       }
     }
 
-    expect(error_?.rule).toBe('invalid-date-format');
+    expect(error_?.rule).toBe('invalid-format');
+    expect(error_?.subcode).toBe('invalid-date-format');
+    expect(error_?.field).toBe('initialDate');
   });
 
-  test('error.rule is correct for invalid time format', () => {
+  test('error.rule is normalized for invalid time format', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -304,10 +308,12 @@ describe('strict mode', () => {
       }
     }
 
-    expect(error_?.rule).toBe('invalid-time-format');
+    expect(error_?.rule).toBe('invalid-format');
+    expect(error_?.subcode).toBe('invalid-time-format');
+    expect(error_?.field).toBe('initialTime');
   });
 
-  test('error.rule is correct for required field', () => {
+  test('error.rule is normalized for required fields', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -326,7 +332,10 @@ describe('strict mode', () => {
       }
     }
 
-    expect(error_?.rule).toBe('action-id-required');
+    expect(error_?.rule).toBe('required-field');
+    expect(error_?.subcode).toBe('action-id-required');
+    expect(error_?.field).toBe('actionId');
+    expect(error_?.component).toBe('Button');
   });
 
   test('error.path includes component context', () => {
@@ -638,7 +647,7 @@ describe('section fields count', () => {
       )).toThrow(SlackblockValidationError);
   });
 
-  test('error.rule is correct when section is missing both text and fields', () => {
+  test('error.rule is normalized when section is missing both text and fields', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -654,7 +663,8 @@ describe('section fields count', () => {
       }
     }
 
-    expect(error_?.rule).toBe('text-or-fields-required');
+    expect(error_?.rule).toBe('invalid-structure');
+    expect(error_?.subcode).toBe('text-or-fields-required');
   });
 });
 
@@ -737,7 +747,7 @@ describe('unknown-type rule', () => {
       )).toThrow(SlackblockValidationError);
   });
 
-  test('strict mode: error.rule is unknown-type', () => {
+  test('strict mode: error.rule is normalized for unknown components', () => {
     let error_: SlackblockValidationError | undefined;
 
     try {
@@ -753,7 +763,9 @@ describe('unknown-type rule', () => {
       }
     }
 
-    expect(error_?.rule).toBe('unknown-type');
+    expect(error_?.rule).toBe('unsupported-child');
+    expect(error_?.subcode).toBe('unknown-type');
+    expect(error_?.component).toBe('UnknownWidget');
   });
 
   test('warn mode: warns on unknown nested component and does not throw', () => {


### PR DESCRIPTION
## Summary
- normalize validation errors onto stable top-level rule categories with optional subcodes
- export typed validation issue metadata for consumers handling strict-mode failures
- update validation docs and README examples to match the new error contract

## What changed
- added `ValidationRule` and `ValidationIssue` types and expanded `SlackblockValidationError` with `subcode`, `component`, `field`, and `issue`
- updated the validation context/reporting pipeline so validators emit normalized categories like `required-field`, `too-long`, `too-many`, `invalid-format`, `invalid-structure`, and `unsupported-child`
- mapped prior granular rule strings into `subcode` values such as `action-id-required`, `value-too-long`, `invalid-date-format`, `text-or-fields-required`, and `unknown-type`
- updated strict-mode validation tests to assert both `rule` and `subcode`
- added migration guidance to the validation docs for consumers upgrading from the old `error.rule` strings

## Testing
- `pnpm test`
