### PR TITLE
Correct Section API

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,19 @@ See [docs/validation.md](docs/validation.md) for the stable rule categories and 
 </Select>
 ```
 
+`<Section>` also supports an explicit `fields` prop and Slack's `expand` flag:
+
+```tsx
+<Section
+  text="Build status"
+  fields={[
+    <Text plainText>Commit</Text>,
+    <Text>{sha}</Text>,
+  ]}
+  expand
+/>
+```
+
 **Conditional rendering** — Use `<Container>` to wrap elements that may or may not render, or use standard JS short-circuit expressions:
 
 ```tsx

--- a/docs/components.md
+++ b/docs/components.md
@@ -51,29 +51,39 @@ A section block. Supports primary text, optional fields, and an optional accesso
 
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
-| `text` | `JSX.Element` | Conditionally | Primary text — typically a `<Text>` element. Required when no field children are present |
+| `text` | `JSX.Element \| string` | Conditionally | Primary text. Required when no `fields` or field children are present |
+| `fields` | `<Text> \| string \| Array<...>` | — | Explicit field content for the two-column section fields area |
 | `blockId` | `string` | — | Unique identifier for the block |
-| `children` | `<Text> \| <Text>[]` | — | Fields displayed in a two-column grid below the text |
+| `children` | `<Text> \| string \| Array<...>` | — | Backward-compatible alias for section fields |
 | `accessory` | block element | — | An interactive element displayed to the right |
+| `expand` | `boolean` | — | Preserve expanded rendering when supported by Slack |
+
+```tsx
+<Section text="Hello *Block Kit*." />
+
+<Section
+  text="Hello *Block Kit*."
+  accessory={<Button actionId="more">More</Button>}
+  fields={[
+    <Text plainText>Field A</Text>,
+    <Text plainText>Field B</Text>,
+  ]}
+/>
+```
+
+Fields-only sections are supported:
 
 ```tsx
 <Section
-  text={<Text>Hello *Block Kit*.</Text>}
-  accessory={<Button actionId="more">More</Button>}
->
-  <Text plainText>Field A</Text>
-  <Text plainText>Field B</Text>
-</Section>
+  fields={[
+    <Text plainText>Status</Text>,
+    <Text>Ready</Text>,
+  ]}
+  expand
+/>
 ```
 
-Runtime validation also accepts fields-only sections. The current TypeScript prop type still requires `text`, so this pattern needs a cast until the `Section` API is widened:
-
-```tsx
-<Section text={undefined as never}>
-  <Text plainText>Status</Text>
-  <Text>Ready</Text>
-</Section>
-```
+`children` still works as a backward-compatible alias for `fields`.
 
 ---
 

--- a/docs/migrating-from-jsx-slack.md
+++ b/docs/migrating-from-jsx-slack.md
@@ -91,13 +91,17 @@ const blocks = renderToBlocks(<Section text={<Text>Hello</Text>} />);
 
 **slackblock** separates concerns explicitly:
 - `text` prop for the primary text (a `<Text>` element with mrkdwn)
-- Children of `<Section>` become fields
+- `fields` prop or children for section fields
 
 ```tsx
 <Section text={<Text>Hello *world*</Text>}>
   <Text>Field A</Text>
   <Text>Field B</Text>
 </Section>
+
+<Section
+  text="Hello *world*"
+  fields={[<Text>Field A</Text>, <Text>Field B</Text>]}/>
 ```
 
 ---

--- a/docs/migrating-from-slack-block-builder.md
+++ b/docs/migrating-from-slack-block-builder.md
@@ -146,15 +146,13 @@ Blocks.Section()
 **slackblock:**
 ```tsx
 <Section
-  text={<Text>Primary text</Text>}
+  text="Primary text"
+  fields={[<Text>Field one</Text>, <Text>Field two</Text>]}
   accessory={<Button actionId="btn">Click</Button>}
->
-  <Text>Field one</Text>
-  <Text>Field two</Text>
-</Section>
+/>
 ```
 
-Fields are passed as children of `<Section>`.
+Fields can be passed via the `fields` prop or as children of `<Section>`.
 
 ---
 

--- a/docs/modeling-audit.md
+++ b/docs/modeling-audit.md
@@ -1,0 +1,26 @@
+# Modeling Audit
+
+Notes from the current API-modeling pass over the supported SlackBlock surface.
+
+## Section
+
+Status: corrected
+
+Changes:
+- `text` is now optional and can be provided as a `string` or `<Text>` element
+- `fields` is now an explicit prop
+- `children` remains supported as a backward-compatible alias for fields
+- `expand` is now modeled and serialized
+
+Result:
+- SlackBlock can now express section blocks with `text`, `fields`, or both
+- fields-only sections no longer require a type cast
+
+## Other supported components
+
+Current audit result:
+- no other supported component required a public API widening in this pass
+
+Follow-up candidates:
+- section accessory compatibility could be validated more explicitly against Slack's supported accessory union
+- broader support-surface documentation still belongs in the support matrix work

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -17,7 +17,7 @@ Internal implementation checklist for the currently supported SlackBlock surface
 | `ImageLayout` | `url`, `alt` | — | `url` 3,000, `alt` 2,000, `title` 2,000, `blockId` 255 | — | — |
 | `Input` | `label`, `element` | — | `label` 2,000, `hint` 2,000, `blockId` 255 | — | — |
 | `RichText` | `elements` | `elements` prop or rich-text children | `blockId` 255 | — | — |
-| `Section` | — | `text` or non-empty `fields` | `blockId` 255, field text 2,000 | `fields` max 10 | — |
+| `Section` | — | `text` or non-empty `fields` | `blockId` 255, field text 2,000 | `fields` max 10 | `expand` serializes when provided |
 | `Video` | `title`, `videoUrl`, `thumbnailUrl`, `altText` | — | `title` 200, `description` 200, `authorName` 50, `blockId` 255 | — | — |
 | `TextInput` | `actionId` | — | `actionId` 255, `placeholder` 150 | — | — |
 | `DatePicker` | `actionId` | — | `actionId` 255, `placeholder` 150 | — | `initialDate` must be `YYYY-MM-DD` |

--- a/src/components/layout/section.tsx
+++ b/src/components/layout/section.tsx
@@ -2,31 +2,42 @@
 import {type BlockElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
-type TextElement = JSX.Element;
+type TextElement = JSX.Element | string;
+type FieldElement = JSX.Element | string;
 
 export type Props = {
-  text: JSX.Element;
+  text?: TextElement;
+  // eslint-disable-next-line @typescript-eslint/no-restricted-types -- We actually want to handle null fields
+  fields?: SingleOrArray<FieldElement | null | undefined | false>;
   blockId?: string;
   // eslint-disable-next-line @typescript-eslint/no-restricted-types -- We actually want to handle null children
-  children?: SingleOrArray<TextElement | null | undefined | false>;
+  children?: SingleOrArray<FieldElement | null | undefined | false>;
   accessory?: BlockElement;
+  expand?: boolean;
 };
 
 /**
  * A section block — the most versatile layout block.
  *
- * Displays a primary text label, optional two-column fields (children),
- * and an optional accessory element on the right.
+ * Displays primary text, optional two-column fields, and an optional
+ * accessory element on the right.
+ *
+ * `fields` is the explicit API for section fields. Children are still
+ * supported as a backward-compatible alias for fields.
+ *
+ * At least one of `text` or non-empty `fields` / children is required.
  *
  * @example
  * ```tsx
+ * <Section text="Hello *world*" />
+ *
  * <Section
  *   text={<Text>Hello *world*</Text>}
+ *   fields={[<Text plainText>Field A</Text>, <Text plainText>Field B</Text>]}
  *   accessory={<Button actionId="more">More</Button>}
- * >
- *   <Text plainText>Field A</Text>
- *   <Text plainText>Field B</Text>
- * </Section>
+ * />
+ *
+ * <Section expand fields={<Text>Status</Text>} />
  * ```
  */
 export default class Section {

--- a/src/transformers/layout/section.ts
+++ b/src/transformers/layout/section.ts
@@ -4,6 +4,7 @@ import {type TextType as Text} from '../block/text';
 import {transform} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireOneOf} from '../../utils/validation';
 import {MAX_BLOCK_ID_LENGTH, MAX_SECTION_FIELD_TEXT, MAX_SECTION_FIELDS} from '../../constants/limits';
+import TextComponent from '../../components/block/text';
 
 export type SectionType = {
   type: 'section';
@@ -11,25 +12,51 @@ export type SectionType = {
   block_id?: string;
   fields?: Text[];
   accessory?: SerializedBlockElement;
+  expand?: boolean;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-restricted-types -- Section fields intentionally allow nullish children.
+type SectionFieldValue = string | JSX.Element | null | undefined | false;
+
+const toTextElement = (value: string | JSX.Element): Element => {
+  if (typeof value === 'string') {
+    return {
+      children: [],
+      type: TextComponent,
+      props: {children: value},
+    } as unknown as Element;
+  }
+
+  return value as Element;
+};
+
+const normalizeFields = (values?: SectionComponentProps['fields']): SectionFieldValue[] => {
+  if (!values) {
+    return [];
+  }
+
+  return Array.isArray(values) ? values : [values];
 };
 
 const transformSection = (element: Element): SectionType => {
-  const {text, blockId, children, accessory} = element.props as SectionComponentProps;
-  const normalizedFields: unknown[] = [];
+  const {
+    text,
+    fields,
+    blockId,
+    children,
+    accessory,
+    expand,
+  } = element.props as SectionComponentProps;
+  const normalizedFields = [...normalizeFields(fields), ...normalizeFields(children)];
 
   warnIfTooLong('block_id', blockId, MAX_BLOCK_ID_LENGTH);
-  if (Array.isArray(children)) {
-    normalizedFields.push(...children);
-  } else if (children) {
-    normalizedFields.push(children);
-  }
 
   const res: SectionType = {
     type: 'section',
   };
 
-  if (text) {
-    res.text = transform(text as Element) as Text;
+  if (text !== undefined) {
+    res.text = transform(toTextElement(text)) as Text;
   }
 
   if (blockId) {
@@ -40,11 +67,15 @@ const transformSection = (element: Element): SectionType => {
     res.accessory = transform(accessory) as SerializedBlockElement;
   }
 
+  if (expand !== undefined) {
+    res.expand = expand;
+  }
+
   if (normalizedFields.length > 0) {
     res.fields = [];
     for (const field of normalizedFields) {
       if (field) {
-        const t = transform(field as Element) as Text;
+        const t = transform(toTextElement(field)) as Text;
         warnIfTooLong('Section field text', t.text, MAX_SECTION_FIELD_TEXT);
         res.fields.push(t);
       }

--- a/test/e2e/pipeline.test.tsx
+++ b/test/e2e/pipeline.test.tsx
@@ -70,6 +70,54 @@ describe('e2e pipeline: basic layout blocks', () => {
     });
   });
 
+  test('renders a Section with explicit fields and expand', () => {
+    const fields = [
+      <Text plainText>Field A</Text>,
+      <Text plainText>Field B</Text>,
+    ];
+
+    const result = render(<Message text="Hello">
+      <Section
+        text="Hello *Block Kit*."
+        fields={fields}
+        expand
+      />
+    </Message>);
+
+    expect(result).toEqual({
+      text: 'Hello',
+      blocks: [
+        {
+          type: 'section',
+          text: {type: 'mrkdwn', text: 'Hello *Block Kit*.'},
+          fields: [
+            {type: 'plain_text', text: 'Field A'},
+            {type: 'plain_text', text: 'Field B'},
+          ],
+          expand: true,
+        },
+      ],
+    });
+  });
+
+  test('renders a Section with fields only', () => {
+    const result = render(<Message text="Hello">
+      <Section fields={<Text plainText>Status</Text>}/>
+    </Message>);
+
+    expect(result).toEqual({
+      text: 'Hello',
+      blocks: [
+        {
+          type: 'section',
+          fields: [
+            {type: 'plain_text', text: 'Status'},
+          ],
+        },
+      ],
+    });
+  });
+
   test('renders Header, Divider, and Context', () => {
     const result = render(<Message>
       <Header text="My Header" emoji/>

--- a/test/transformers/layout/section.test.tsx
+++ b/test/transformers/layout/section.test.tsx
@@ -7,7 +7,7 @@ import transformer from '../../../src/transformers/layout/section';
 test('it transforms a basic Section component', () => {
   const element = (
     <Section
-      text={<Text>FooBar</Text>}
+      text="FooBar"
     />
   );
 
@@ -25,11 +25,11 @@ test('it transforms a basic Section component', () => {
 test('it transforms a more complex Section', () => {
   const res = transformer(<Section
     text={<Text>FooBar</Text>}
+    fields={<Text>OtherText</Text>}
     blockId="abc123"
     accessory={<Text>Accessory</Text>}
-  >
-    <Text>OtherText</Text>
-  </Section>);
+    expand
+  />);
 
   expect(res).toEqual({
     type: 'section',
@@ -48,6 +48,7 @@ test('it transforms a more complex Section', () => {
       type: 'mrkdwn',
       text: 'Accessory',
     },
+    expand: true,
   });
 });
 
@@ -67,6 +68,25 @@ test('it does not break if there is a null field', () => {
       type: 'mrkdwn',
       text: 'Foo',
     },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: 'More text',
+      },
+      {
+        type: 'mrkdwn',
+        text: 'Even more',
+      },
+    ],
+  });
+});
+
+test('it supports fields-only sections via the fields prop', () => {
+  const fields = [<Text>More text</Text>, null, <Text>Even more</Text>];
+  const res = transformer(<Section fields={fields}/>);
+
+  expect(res).toEqual({
+    type: 'section',
     fields: [
       {
         type: 'mrkdwn',

--- a/test/validation/validation.test.tsx
+++ b/test/validation/validation.test.tsx
@@ -582,9 +582,7 @@ describe('section fields count', () => {
     expect(() =>
       render(
         <Message>
-          <Section text={undefined as unknown as JSX.Element}>
-            <Text>Field only</Text>
-          </Section>
+          <Section fields={<Text>Field only</Text>}/>
         </Message>,
         {validate: 'strict'},
       )).not.toThrow();
@@ -596,7 +594,7 @@ describe('section fields count', () => {
     expect(() =>
       render(
         <Message>
-          <Section text={undefined as unknown as JSX.Element}/>
+          <Section/>
         </Message>,
         {validate: 'warn'},
       )).not.toThrow();
@@ -609,7 +607,7 @@ describe('section fields count', () => {
     expect(() =>
       render(
         <Message>
-          <Section text={undefined as unknown as JSX.Element}/>
+          <Section/>
         </Message>,
         {validate: 'strict'},
       )).toThrow(SlackblockValidationError);
@@ -653,7 +651,7 @@ describe('section fields count', () => {
     try {
       render(
         <Message>
-          <Section text={undefined as unknown as JSX.Element}/>
+          <Section/>
         </Message>,
         {validate: 'strict'},
       );


### PR DESCRIPTION
## Summary
- make the public `Section` API match the supported Slack combinations more closely
- add explicit support for section `fields` and `expand` while keeping children-based fields backward compatible
- update tests and docs to reflect the corrected section model

## What changed
- changed `<Section>` so `text` is optional and may be provided as either a `string` or `<Text>` element
- added a `fields` prop for explicit section fields
- kept `children` as a backward-compatible alias for section fields
- added `expand` support to section serialization
- updated the section transformer so it accepts `text`, `fields`, `text + fields`, and fields-only sections
- added unit, validation, and end-to-end coverage for the new section combinations
- updated component docs and migration guides, and added a small modeling audit note

## Testing
- `pnpm test`
