### PR TITLE
Document support coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ JSX-based Slack Block Kit message renderer
 
 Build Slack messages with JSX. No React required — SlackBlock ships its own lightweight JSX runtime. Write your blocks as components, call `render()`, and post the result straight to the Slack API.
 
+SlackBlock supports a documented subset of Slack Block Kit rather than the full surface area. See [docs/support-matrix.md](docs/support-matrix.md) for the current coverage and [docs/roadmap.md](docs/roadmap.md) for the main gaps being tracked.
+
 ---
 
 ## Compatibility
@@ -257,25 +259,23 @@ See [docs/validation.md](docs/validation.md) for the stable rule categories and 
 
 ---
 
-## Supported components
+## Support Coverage
 
-**Layout blocks:** `Message`, `Section`, `Actions`, `Context`, `Divider`, `File`, `Header`, `Image` (block), `Input`, `RichText`, `Video`
+SlackBlock does not try to mirror every Slack Block Kit primitive immediately. The supported subset is explicit:
 
-**Block elements:** `Text`, `Image` (element), `Button`, `Confirmation`
+- supported coverage: [docs/support-matrix.md](docs/support-matrix.md)
+- public component API: [docs/components.md](docs/components.md)
+- planned gaps: [docs/roadmap.md](docs/roadmap.md)
 
-**Input elements:** `Select`, `Option`, `OptionGroup`, `Overflow`, `Checkboxes`, `RadioGroup`, `TextInput`, `DatePicker`, `TimePicker`, `DateTimePicker`
-
-**Rich text helpers:** `RichTextSection`, `RichTextList`, `RichTextQuote`, `RichTextPreformatted`, `RichTextText`, `RichTextLink`, `RichTextUser`, `RichTextChannel`, `RichTextEmoji`, `RichTextDate`, `RichTextBroadcast`, `RichTextUserGroup`
-
-**Utility:** `Container`
-
-See [docs/components.md](docs/components.md) for the full props reference.
+If a block, element, or composition object is not listed as `Supported` in the support matrix, do not assume it is available.
 
 ---
 
 ## Further reading
 
 - [Component reference](docs/components.md) — all components with props tables
+- [Support matrix](docs/support-matrix.md) — current Block Kit coverage
+- [Roadmap](docs/roadmap.md) — tracked gaps and likely next additions
 - [Validation guide](docs/validation.md) — validation modes and error handling
 - [Migrating from jsx-slack](docs/migrating-from-jsx-slack.md)
 - [Migrating from slack-block-builder](docs/migrating-from-slack-block-builder.md)

--- a/docs/components.md
+++ b/docs/components.md
@@ -9,6 +9,8 @@ import {
 } from 'slackblock/block';
 ```
 
+For current support status across Slack Block Kit features, see [support-matrix.md](./support-matrix.md).
+
 ---
 
 ## Layout blocks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,50 @@
+# Roadmap
+
+This is the current list of notable Block Kit gaps that fit SlackBlock's direction and are worth tracking.
+
+## Suggested Roadmap Items
+
+### Blocks
+
+1. `markdown` block
+   Reason: useful modern text surface that Slack now supports directly.
+
+2. `table` block
+   Reason: common layout need and a notable gap in the current block set.
+
+3. `context_actions` block
+   Reason: newer compact action surface that pairs with Slack's AI-oriented UX.
+
+### Elements
+
+1. `workflow_button`
+   Reason: fills a modern interactive gap and needs dedicated API design.
+
+2. `icon_button`
+   Reason: appears in newer compact-action patterns and should be modeled explicitly.
+
+3. `feedback_buttons`
+   Reason: modern Slack feedback patterns are increasingly common in AI-style message flows.
+
+4. `file_input`
+   Reason: useful for modal-style workflows and currently absent from the input set.
+
+5. `number_input`, `email_text_input`, `url_text_input`
+   Reason: these extend the input surface in predictable ways and fit the package's existing form model.
+
+6. `rich_text_input`
+   Reason: complements the existing rich-text output support.
+
+### Composition Objects
+
+1. `slack_file` image sources
+   Reason: image blocks and image elements currently only support public URLs.
+
+2. broader dispatch-action configuration support
+   Reason: the object exists today, but support is narrower than Slack's full reusable shape.
+
+## Notes
+
+- These are roadmap candidates, not guarantees.
+- The support matrix remains the source of truth for what is implemented now.
+- When a roadmap item lands, update both `docs/support-matrix.md` and the public component reference.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,108 @@
+# Support Matrix
+
+SlackBlock supports a focused subset of Slack Block Kit. This document is the source of truth for what is currently modeled in the public API.
+
+Status meanings:
+- `Supported`: first-class component or helper exists and is documented
+- `Partially supported`: some supported behavior exists, but not the full Slack surface
+- `Planned`: not implemented yet, but a reasonable future fit for the package
+- `Not supported`: currently outside the implemented scope
+
+## Blocks
+
+| Slack feature | Status | Notes |
+|---|---|---|
+| `actions` block | Supported | `<Actions>` |
+| `context` block | Supported | `<Context>` |
+| `divider` block | Supported | `<Divider>` |
+| `file` block | Supported | `<File>` for remote files |
+| `header` block | Supported | `<Header>` |
+| `image` block | Supported | `<ImageLayout>` |
+| `input` block | Supported | `<Input>` |
+| `rich_text` block | Supported | `<RichText>` and rich-text helper components |
+| `section` block | Supported | Supports `text`, `fields`, `text + fields`, and `expand` |
+| `video` block | Supported | `<Video>` |
+| `markdown` block | Planned | Not implemented yet |
+| `table` block | Planned | Not implemented yet |
+| `context_actions` block | Planned | Modern AI/feedback block, not implemented yet |
+| `plan` block | Not supported | AI/task-specific block, not modeled today |
+| `task_card` block | Not supported | AI/task-specific block, not modeled today |
+
+## Block Elements
+
+| Slack feature | Status | Notes |
+|---|---|---|
+| `button` element | Supported | `<Button>` |
+| `checkboxes` element | Supported | `<Checkboxes>` |
+| `datepicker` element | Supported | `<DatePicker>` |
+| `datetimepicker` element | Supported | `<DateTimePicker>` |
+| `image` element | Supported | `<Image>` |
+| `overflow` element | Supported | `<Overflow>` |
+| `plain_text_input` element | Supported | `<TextInput>` |
+| `radio_buttons` element | Supported | `<RadioGroup>` |
+| `static_select` / `multi_static_select` | Supported | `<Select>` with default `type="static"` |
+| `external_select` / `multi_external_select` | Supported | `<Select type="external">` |
+| `users_select` / `multi_users_select` | Supported | `<Select type="user">` |
+| `conversations_select` / `multi_conversations_select` | Supported | `<Select type="conversation">` |
+| `channels_select` / `multi_channels_select` | Supported | `<Select type="channel">` |
+| `workflow_button` element | Planned | No API yet |
+| `icon_button` element | Planned | No API yet |
+| `feedback_buttons` element | Planned | No API yet |
+| `file_input` element | Planned | No API yet |
+| `number_input` element | Planned | No API yet |
+| `email_text_input` element | Planned | No API yet |
+| `url_text_input` element | Planned | No API yet |
+| `rich_text_input` element | Planned | No API yet |
+
+## Composition Objects
+
+| Slack feature | Status | Notes |
+|---|---|---|
+| Text object | Supported | `<Text>` and rich-text helpers |
+| Confirmation dialog object | Supported | `<Confirmation>` |
+| Option object | Supported | `<Option>` |
+| Option group object | Supported | `<OptionGroup>` |
+| Conversation filter object | Partially supported | Supported through `Select.filter`, not as a standalone helper |
+| Dispatch action configuration object | Partially supported | Supported on `<TextInput>` only |
+| Slack file object | Not supported | Image blocks/elements do not support `slack_file` yet |
+| Trigger object | Planned | Would arrive with workflow button support |
+| Workflow object | Planned | Would arrive with workflow button support |
+
+## Rich Text Helpers
+
+| Slack feature | Status | Notes |
+|---|---|---|
+| `rich_text_section` | Supported | `<RichTextSection>` |
+| `rich_text_list` | Supported | `<RichTextList>` |
+| `rich_text_quote` | Supported | `<RichTextQuote>` |
+| `rich_text_preformatted` | Supported | `<RichTextPreformatted>` |
+| text run | Supported | `<RichTextText>` |
+| link | Supported | `<RichTextLink>` |
+| user mention | Supported | `<RichTextUser>` |
+| channel mention | Supported | `<RichTextChannel>` |
+| user group mention | Supported | `<RichTextUserGroup>` |
+| emoji | Supported | `<RichTextEmoji>` |
+| date token | Supported | `<RichTextDate>` |
+| broadcast mention | Supported | `<RichTextBroadcast>` |
+
+## Helpers and Runtime
+
+| Feature | Status | Notes |
+|---|---|---|
+| `<Message>` wrapper | Supported | Root message component |
+| `<Container>` helper | Supported | Non-Slack helper for conditional composition |
+| `render()` | Supported | Full message payload renderer |
+| `renderToMessage()` | Supported | Named alias of `render()` |
+| `renderToBlocks()` | Supported | Block-array renderer for modals/home tabs |
+| Validation modes | Supported | `off`, `warn`, `strict` |
+| `SlackblockValidationError` | Supported | Stable rule categories with optional subcodes |
+| `escapeMrkdwn()` | Supported | Escapes untrusted mrkdwn input |
+| `blockKitBuilderUrl()` | Supported | Builder preview URL generator |
+| JSX runtime | Supported | `jsx-runtime` / `jsx-dev-runtime` exports |
+| Legacy attachment color wrapper | Supported | `Message.color` wraps blocks in an attachment |
+
+## Notes
+
+- New Slack features are not automatically supported just because they exist in Block Kit.
+- If a feature is not marked `Supported`, treat it as unavailable until the matrix changes.
+- The component reference documents the supported API shape; this matrix defines the supported Slack surface.


### PR DESCRIPTION
## Summary
- document the current Slack Block Kit surface that SlackBlock supports
- make README positioning explicit that the package supports a subset of Block Kit
- add a roadmap doc for the main missing Slack capabilities that fit the project scope

## What changed
- added `docs/support-matrix.md` with explicit status markers for blocks, block elements, composition objects, rich-text helpers, and runtime features
- updated `README.md` to point readers at the support matrix and clarify that unlisted Slack features are not implicitly supported
- added `docs/roadmap.md` covering the main tracked gaps such as `markdown`, `table`, `context_actions`, `workflow_button`, `icon_button`, and `feedback_buttons`
- added a support-matrix cross-link in `docs/components.md`

## Testing
- docs-only change; tests not run
