### PR TITLE
Strengthen tests and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
         run: pnpm run test:lint
       - name: Typecheck
         run: pnpm run test:tsc
-      - name: Unit tests
-        run: pnpm run test:unit
+      - name: Coverage
+        run: pnpm run test:coverage
       - name: Build
         run: pnpm run build
 
@@ -46,3 +46,23 @@ jobs:
           if [ "${{ needs.build.result }}" != "success" ]; then
             exit 1
           fi
+
+  package-smoke:
+    runs-on: ubuntu-latest
+    needs: build-ok
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Packed artifact smoke test
+        run: pnpm run test:smoke

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "test:lint": "xo --fix",
     "test:knip": "knip",
     "test:unit": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:smoke": "pnpm run build && node ./test/smoke/packed-artifact.mjs",
     "prebuild": "pnpm run clean",
     "clean": "rimraf ./dist",
     "build": "tsup",

--- a/test/fixtures/packed-artifact/package.json
+++ b/test/fixtures/packed-artifact/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "slackblock-packed-artifact-fixture",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "slackblock": "file:__TARBALL__"
+  }
+}

--- a/test/fixtures/packed-artifact/smoke.mjs
+++ b/test/fixtures/packed-artifact/smoke.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import {createRequire} from 'node:module';
+
+import render, {
+  SlackblockValidationError,
+  blockKitBuilderUrl,
+  escapeMrkdwn,
+  renderToBlocks,
+  renderToMessage,
+} from 'slackblock';
+import {
+  Header,
+  Message,
+  Section,
+  Text,
+} from 'slackblock/block';
+import {jsx, jsxs, Fragment} from 'slackblock/jsx-runtime';
+import {jsxDEV} from 'slackblock/jsx-dev-runtime';
+
+const require = createRequire(import.meta.url);
+const cjsRoot = require('slackblock');
+const cjsRuntime = require('slackblock/jsx-runtime');
+
+assert.equal(typeof render, 'function');
+assert.equal(renderToMessage, render);
+assert.equal(typeof renderToBlocks, 'function');
+assert.equal(typeof escapeMrkdwn, 'function');
+assert.equal(typeof blockKitBuilderUrl, 'function');
+assert.equal(typeof SlackblockValidationError, 'function');
+assert.equal(typeof cjsRoot.default, 'function');
+assert.equal(typeof cjsRuntime.jsx, 'function');
+assert.equal(Fragment, 'fragment');
+assert.equal(typeof jsxDEV, 'function');
+
+const message = jsxs(Message, {
+  text: 'Fallback',
+  children: [
+    jsxDEV(Header, {text: 'Packed artifact header'}),
+    jsx(Section, {
+      text: jsx(Text, {children: `Escaped: ${escapeMrkdwn('*bold*')}`}),
+    }),
+  ],
+});
+
+const payload = render(message, {channel: 'C123'});
+const blocks = renderToBlocks(jsxs(Fragment, {
+  children: [
+    jsx(Header, {text: 'Blocks header'}),
+    jsx(Section, {text: jsx(Text, {children: 'Blocks body'})}),
+  ],
+}));
+
+assert.equal(payload.channel, 'C123');
+assert.equal(payload.blocks.length, 2);
+assert.equal(blocks.length, 2);
+assert.match(blockKitBuilderUrl(payload), /^https:\/\/app\.slack\.com\/block-kit-builder/u);
+
+console.log('packed artifact smoke test passed');

--- a/test/fixtures/packed-artifact/src/index.tsx
+++ b/test/fixtures/packed-artifact/src/index.tsx
@@ -1,0 +1,28 @@
+import render, {
+  type SlackPostMessagePayload,
+  renderToBlocks,
+} from 'slackblock';
+import {
+  Header,
+  Message,
+  Section,
+  Text,
+} from 'slackblock/block';
+
+const payload: SlackPostMessagePayload = render(
+  <Message text="Fixture fallback">
+    <Header text="Fixture header"/>
+    <Section text={<Text>Fixture body</Text>}/>
+  </Message>,
+  {channel: 'C123'},
+);
+
+const blocks = renderToBlocks(
+  <>
+    <Header text="Standalone blocks"/>
+    <Section text={<Text>Standalone text</Text>}/>
+  </>,
+);
+
+void payload;
+void blocks;

--- a/test/fixtures/packed-artifact/tsconfig.json
+++ b/test/fixtures/packed-artifact/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "jsxImportSource": "slackblock",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/test/public-api/exports.test.ts
+++ b/test/public-api/exports.test.ts
@@ -1,0 +1,58 @@
+import {expect, test} from 'vitest';
+
+import render, {
+  SlackblockValidationError,
+  blockKitBuilderUrl,
+  escapeMrkdwn,
+  renderToBlocks,
+  renderToMessage,
+} from '../../src';
+import * as block from '../../src/block';
+import * as jsxDevRuntime from '../../src/jsx-dev-runtime';
+import * as jsxRuntime from '../../src/jsx-runtime';
+
+test('root entrypoint exports renderer and helpers', () => {
+  expect(render).toBeTypeOf('function');
+  expect(renderToMessage).toBe(render);
+  expect(renderToBlocks).toBeTypeOf('function');
+  expect(escapeMrkdwn).toBeTypeOf('function');
+  expect(blockKitBuilderUrl).toBeTypeOf('function');
+  expect(SlackblockValidationError).toBeTypeOf('function');
+});
+
+test('block entrypoint exports the public component barrel', () => {
+  expect(block.Message.slackType).toBe('Message');
+  expect(block.Actions.slackType).toBe('Actions');
+  expect(block.Button.slackType).toBe('Button');
+  expect(block.Container.slackType).toBe('Container');
+  expect(block.Header.slackType).toBe('Header');
+  expect(block.Input.slackType).toBe('Input');
+  expect(block.Section.slackType).toBe('Section');
+  expect(block.Text.slackType).toBe('Text');
+});
+
+test('jsx-runtime exports the automatic runtime helpers', () => {
+  const element = jsxRuntime.jsxs(block.Message, {
+    text: 'Fallback',
+    children: [
+      jsxRuntime.jsx(block.Header, {text: 'Packed artifact'}),
+      jsxRuntime.jsx(block.Section, {
+        text: jsxRuntime.jsx(block.Text, {children: 'Hello'}),
+      }),
+    ],
+  });
+
+  expect(jsxRuntime.jsx).toBeTypeOf('function');
+  expect(jsxRuntime.jsxs).toBeTypeOf('function');
+  expect(jsxRuntime.Fragment).toBe('fragment');
+  expect(element.type).toBe(block.Message);
+  expect(element.children).toHaveLength(2);
+});
+
+test('jsx-dev-runtime re-exports jsxDEV and Fragment', () => {
+  const element = jsxDevRuntime.jsxDEV(block.Header, {text: 'Hello'});
+
+  expect(jsxDevRuntime.jsxDEV).toBe(jsxRuntime.jsx);
+  expect(jsxDevRuntime.Fragment).toBe(jsxRuntime.Fragment);
+  expect(element.type).toBe(block.Header);
+});

--- a/test/smoke/packed-artifact.mjs
+++ b/test/smoke/packed-artifact.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const fixtureTemplate = path.join(projectRoot, 'test/fixtures/packed-artifact');
+const tempRoot = mkdtempSync(path.join(tmpdir(), 'slackblock-packed-artifact-'));
+const fixtureRoot = path.join(tempRoot, 'fixture');
+const distRoot = path.join(tempRoot, 'pack');
+const npmCacheRoot = path.join(tempRoot, 'npm-cache');
+const nodeModulesRoot = path.join(fixtureRoot, 'node_modules');
+
+assert.ok(existsSync(path.join(projectRoot, 'dist/index.cjs')), 'dist/index.cjs must exist before packing');
+
+cpSync(fixtureTemplate, fixtureRoot, {recursive: true});
+mkdirSync(distRoot, {recursive: true});
+
+const [tarballName] = JSON.parse(
+  execFileSync('npm', ['pack', '--ignore-scripts', '--pack-destination', distRoot, '--json'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_cache: npmCacheRoot,
+    },
+  }),
+);
+const tarballPath = path.join(distRoot, tarballName.filename);
+
+const packageJsonPath = path.join(fixtureRoot, 'package.json');
+const packageJson = readFileSync(packageJsonPath, 'utf8').replace('__TARBALL__', tarballPath);
+writeFileSync(packageJsonPath, packageJson);
+
+if (process.env.CI) {
+  execFileSync('pnpm', ['install', '--ignore-scripts'], {
+    cwd: fixtureRoot,
+    stdio: 'inherit',
+  });
+} else {
+  mkdirSync(nodeModulesRoot, {recursive: true});
+  execFileSync('tar', ['-xzf', tarballPath, '-C', fixtureRoot], {
+    stdio: 'inherit',
+  });
+  renameSync(path.join(fixtureRoot, 'package'), path.join(nodeModulesRoot, 'slackblock'));
+  mkdirSync(path.join(nodeModulesRoot, '@slack'), {recursive: true});
+  cpSync(
+    path.join(projectRoot, 'node_modules/@slack/types'),
+    path.join(nodeModulesRoot, '@slack/types'),
+    {recursive: true},
+  );
+}
+
+execFileSync(process.execPath, [path.join(projectRoot, 'node_modules/typescript/bin/tsc'), '-p', path.join(fixtureRoot, 'tsconfig.json'), '--noEmit'], {
+  cwd: projectRoot,
+  stdio: 'inherit',
+});
+
+const output = execFileSync(process.execPath, ['smoke.mjs'], {
+  cwd: fixtureRoot,
+  encoding: 'utf8',
+});
+
+assert.match(output, /packed artifact smoke test passed/u);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "..",
     "lib": ["ES2022", "dom", "esnext.disposable"]
   },
-  "include": ["./**/*", "../src/jsx.d.ts"]
+  "include": ["./**/*", "../src/jsx.d.ts"],
+  "exclude": ["./fixtures/packed-artifact/**/*"]
 }

--- a/test/validation/conformance.test.tsx
+++ b/test/validation/conformance.test.tsx
@@ -1,0 +1,470 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
+
+import render, {SlackblockValidationError} from '../../src';
+import {
+  Actions,
+  Button,
+  Checkboxes,
+  Confirmation,
+  Context,
+  DatePicker,
+  DateTimePicker,
+  File,
+  Header,
+  Image,
+  ImageLayout,
+  Input,
+  Message,
+  Option,
+  OptionGroup,
+  Overflow,
+  RadioGroup,
+  RichText,
+  RichTextSection,
+  RichTextText,
+  Section,
+  Select,
+  Text,
+  TextInput,
+  TimePicker,
+  Video,
+} from '../../src/components';
+
+type ValidationCase = {
+  name: string;
+  component: string;
+  valid: JSX.Element;
+  invalid: JSX.Element;
+  rule: 'required-field' | 'invalid-structure';
+  subcode: string;
+  field?: string;
+};
+
+const option = <Option value="opt-1">Option 1</Option>;
+const missingString = undefined as never;
+const missingElement = undefined as never;
+
+const validationCases: ValidationCase[] = [
+  {
+    name: 'Actions',
+    component: 'Actions',
+    valid: <Message><Actions><Button actionId="approve">Approve</Button></Actions></Message>,
+    invalid: <Message><Actions>{missingElement}</Actions></Message>,
+    rule: 'required-field',
+    subcode: 'elements-required',
+    field: 'elements',
+  },
+  {
+    name: 'Context',
+    component: 'Context',
+    valid: <Message><Context><Text plainText>Context</Text></Context></Message>,
+    invalid: <Message><Context>{missingElement}</Context></Message>,
+    rule: 'required-field',
+    subcode: 'elements-required',
+    field: 'elements',
+  },
+  {
+    name: 'File',
+    component: 'File',
+    valid: <Message><File externalId="ext-1"/></Message>,
+    invalid: <Message><File externalId={missingString}/></Message>,
+    rule: 'required-field',
+    subcode: 'external-id-required',
+    field: 'externalId',
+  },
+  {
+    name: 'Header',
+    component: 'Header',
+    valid: <Message><Header text="Hello"/></Message>,
+    invalid: <Message><Header text={missingString}/></Message>,
+    rule: 'required-field',
+    subcode: 'text-required',
+    field: 'text',
+  },
+  {
+    name: 'ImageLayout',
+    component: 'ImageLayout',
+    valid: <Message><ImageLayout url="https://example.com/image.png" alt="Chart"/></Message>,
+    invalid: <Message><ImageLayout url={missingString} alt="Chart"/></Message>,
+    rule: 'required-field',
+    subcode: 'url-required',
+    field: 'url',
+  },
+  {
+    name: 'Input',
+    component: 'Input',
+    valid: <Message><Input label="Name" element={<TextInput actionId="name"/>}/></Message>,
+    invalid: <Message><Input label={missingString} element={<TextInput actionId="name"/>}/></Message>,
+    rule: 'required-field',
+    subcode: 'label-required',
+    field: 'label',
+  },
+  {
+    name: 'RichText',
+    component: 'RichText',
+    valid: <Message><RichText><RichTextSection><RichTextText>Hi</RichTextText></RichTextSection></RichText></Message>,
+    invalid: <Message><RichText/></Message>,
+    rule: 'required-field',
+    subcode: 'elements-required',
+    field: 'elements',
+  },
+  {
+    name: 'Section',
+    component: 'Section',
+    valid: <Message><Section text={<Text>Hello</Text>}/></Message>,
+    invalid: <Message><Section/></Message>,
+    rule: 'invalid-structure',
+    subcode: 'text-or-fields-required',
+  },
+  {
+    name: 'Video',
+    component: 'Video',
+    valid: <Message><Video title="Demo" videoUrl="https://example.com/video" thumbnailUrl="https://example.com/thumb" altText="Video thumbnail"/></Message>,
+    invalid: <Message><Video title={missingString} videoUrl="https://example.com/video" thumbnailUrl="https://example.com/thumb" altText="Video thumbnail"/></Message>,
+    rule: 'required-field',
+    subcode: 'title-required',
+    field: 'title',
+  },
+  {
+    name: 'Button',
+    component: 'Button',
+    valid: <Message><Actions><Button actionId="approve">Approve</Button></Actions></Message>,
+    invalid: <Message><Actions><Button actionId={missingString}>Approve</Button></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'Confirmation',
+    component: 'Confirmation',
+    valid: <Message>
+      <Actions>
+        <Button
+          actionId="delete"
+          confirm={<Confirmation title="Confirm" confirm="Delete" deny="Cancel"><Text plainText>Delete it?</Text></Confirmation>}
+        >
+          Delete
+        </Button>
+      </Actions>
+    </Message>,
+    invalid: <Message>
+      <Actions>
+        <Button
+          actionId="delete"
+          confirm={<Confirmation title="Confirm" confirm="Delete" deny="Cancel">{missingElement}</Confirmation>}
+        >
+          Delete
+        </Button>
+      </Actions>
+    </Message>,
+    rule: 'required-field',
+    subcode: 'text-required',
+    field: 'text',
+  },
+  {
+    name: 'Image',
+    component: 'Image',
+    valid: <Message><Section text={<Text>Hello</Text>} accessory={<Image url="https://example.com/icon.png" alt="Icon"/>}/></Message>,
+    invalid: <Message><Section text={<Text>Hello</Text>} accessory={<Image url="https://example.com/icon.png" alt={missingString}/>}/></Message>,
+    rule: 'required-field',
+    subcode: 'alt-required',
+    field: 'alt',
+  },
+  {
+    name: 'Text',
+    component: 'Text',
+    valid: <Message><Section text={<Text>Hello</Text>}/></Message>,
+    invalid: <Message><Section text={<Text>{missingString}</Text>}/></Message>,
+    rule: 'required-field',
+    subcode: 'text-required',
+    field: 'text',
+  },
+  {
+    name: 'Checkboxes',
+    component: 'Checkboxes',
+    valid: <Message><Input label="Choices" element={<Checkboxes actionId="choices">{option}</Checkboxes>}/></Message>,
+    invalid: <Message><Input label="Choices" element={<Checkboxes actionId={missingString}>{option}</Checkboxes>}/></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'DatePicker',
+    component: 'DatePicker',
+    valid: <Message><Actions><DatePicker actionId="date"/></Actions></Message>,
+    invalid: <Message><Actions><DatePicker actionId={missingString}/></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'DateTimePicker',
+    component: 'DateTimePicker',
+    valid: <Message><Actions><DateTimePicker actionId="date-time"/></Actions></Message>,
+    invalid: <Message><Actions><DateTimePicker actionId={missingString}/></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'Option',
+    component: 'Option',
+    valid: <Message><Actions><Overflow actionId="overflow">{option}</Overflow></Actions></Message>,
+    invalid: <Message><Actions><Overflow actionId="overflow"><Option value={missingString}>Option 1</Option></Overflow></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'value-required',
+    field: 'value',
+  },
+  {
+    name: 'OptionGroup',
+    component: 'OptionGroup',
+    valid: <Message><Input label="Grouped" element={<Select placeholder="Choose" actionId="grouped"><OptionGroup label="Group">{option}</OptionGroup></Select>}/></Message>,
+    invalid: <Message><Input label="Grouped" element={<Select placeholder="Choose" actionId="grouped"><OptionGroup label={missingString}>{option}</OptionGroup></Select>}/></Message>,
+    rule: 'required-field',
+    subcode: 'label-required',
+    field: 'label',
+  },
+  {
+    name: 'Overflow',
+    component: 'Overflow',
+    valid: <Message><Actions><Overflow actionId="overflow">{option}</Overflow></Actions></Message>,
+    invalid: <Message><Actions><Overflow actionId={missingString}>{option}</Overflow></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'RadioGroup',
+    component: 'RadioGroup',
+    valid: <Message><Input label="Pick one" element={<RadioGroup actionId="radio">{option}</RadioGroup>}/></Message>,
+    invalid: <Message><Input label="Pick one" element={<RadioGroup actionId={missingString}>{option}</RadioGroup>}/></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'Select',
+    component: 'Select',
+    valid: <Message><Input label="Select" element={<Select placeholder="Choose" actionId="select">{option}</Select>}/></Message>,
+    invalid: <Message><Input label="Select" element={<Select placeholder={missingString} actionId="select">{option}</Select>}/></Message>,
+    rule: 'required-field',
+    subcode: 'placeholder-required',
+    field: 'placeholder',
+  },
+  {
+    name: 'TextInput',
+    component: 'TextInput',
+    valid: <Message><Input label="Name" element={<TextInput actionId="name"/>}/></Message>,
+    invalid: <Message><Input label="Name" element={<TextInput actionId={missingString}/>}/></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+  {
+    name: 'TimePicker',
+    component: 'TimePicker',
+    valid: <Message><Actions><TimePicker actionId="time"/></Actions></Message>,
+    invalid: <Message><Actions><TimePicker actionId={missingString}/></Actions></Message>,
+    rule: 'required-field',
+    subcode: 'action-id-required',
+    field: 'actionId',
+  },
+];
+
+const captureValidationError = (element: JSX.Element): SlackblockValidationError | undefined => {
+  try {
+    render(element, {validate: 'strict'});
+  } catch (error) {
+    if (error instanceof SlackblockValidationError) {
+      return error;
+    }
+
+    throw error;
+  }
+
+  return undefined;
+};
+
+describe('supported component validation conformance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test.each(validationCases)('accepts minimal valid payload for $name', ({valid}) => {
+    expect(() => render(valid, {validate: 'strict'})).not.toThrow();
+  });
+
+  test.each(validationCases)('normalizes missing required validation for $name', ({
+    invalid,
+    component,
+    field,
+    rule,
+    subcode,
+  }) => {
+    const error = captureValidationError(invalid);
+
+    expect(error).toBeInstanceOf(SlackblockValidationError);
+    expect(error?.component).toBe(component);
+    expect(error?.field).toBe(field);
+    expect(error?.rule).toBe(rule);
+    expect(error?.subcode).toBe(subcode);
+  });
+
+  test.each(validationCases)('warn mode emits a warning for invalid $name payloads', ({invalid}) => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(() => render(invalid, {validate: 'warn'})).not.toThrow();
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('[slackblock]'));
+  });
+
+  test.each(validationCases)('off mode ignores invalid $name payloads', ({invalid}) => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(() => render(invalid, {validate: 'off'})).not.toThrow();
+    expect(warning).not.toHaveBeenCalled();
+  });
+});
+
+describe('validation boundary conformance', () => {
+  test('enforces max action elements', () => {
+    const buttons = Array.from({length: 30}, (_, index) => (
+      <Button actionId={`action-${index}`}>{`Action ${index}`}</Button>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Actions>{buttons}</Actions>
+    </Message>);
+
+    expect(error?.component).toBe('Actions');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max section fields', () => {
+    const fields = Array.from({length: 11}, (_, index) => (
+      <Text>{`Field ${index}`}</Text>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Section text={<Text>Body</Text>}>{fields}</Section>
+    </Message>);
+
+    expect(error?.component).toBe('Section');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max overflow options', () => {
+    const options = Array.from({length: 6}, (_, index) => (
+      <Option value={`overflow-${index}`}>{`Overflow ${index}`}</Option>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Actions>
+        <Overflow actionId="overflow">{options}</Overflow>
+      </Actions>
+    </Message>);
+
+    expect(error?.component).toBe('Overflow');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max checkboxes options', () => {
+    const options = Array.from({length: 11}, (_, index) => (
+      <Option value={`checkbox-${index}`}>{`Checkbox ${index}`}</Option>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Input label="Choices" element={<Checkboxes actionId="checks">{options}</Checkboxes>}/>
+    </Message>);
+
+    expect(error?.component).toBe('Checkboxes');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max radio options', () => {
+    const options = Array.from({length: 11}, (_, index) => (
+      <Option value={`radio-${index}`}>{`Radio ${index}`}</Option>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Input label="Pick one" element={<RadioGroup actionId="radio">{options}</RadioGroup>}/>
+    </Message>);
+
+    expect(error?.component).toBe('RadioGroup');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max select options', () => {
+    const options = Array.from({length: 101}, (_, index) => (
+      <Option value={`select-${index}`}>{`Select ${index}`}</Option>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Input label="Pick one" element={<Select placeholder="Pick" actionId="select">{options}</Select>}/>
+    </Message>);
+
+    expect(error?.component).toBe('Select');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max option group options', () => {
+    const options = Array.from({length: 101}, (_, index) => (
+      <Option value={`group-${index}`}>{`Group ${index}`}</Option>
+    ));
+
+    const error = captureValidationError(<Message>
+      <Input label="Grouped" element={<Select placeholder="Choose" actionId="grouped"><OptionGroup label="Group">{options}</OptionGroup></Select>}/>
+    </Message>);
+
+    expect(error?.component).toBe('OptionGroup');
+    expect(error?.rule).toBe('too-many');
+    expect(error?.subcode).toBe('too-many-items');
+  });
+
+  test('enforces max header length', () => {
+    const error = captureValidationError(<Message>
+      <Header text={'A'.repeat(151)}/>
+    </Message>);
+
+    expect(error?.component).toBe('Header');
+    expect(error?.rule).toBe('too-long');
+    expect(error?.subcode).toBe('value-too-long');
+  });
+
+  test('enforces date format', () => {
+    const error = captureValidationError(<Message>
+      <Actions>
+        <DatePicker actionId="date" initialDate="2026/03/07"/>
+      </Actions>
+    </Message>);
+
+    expect(error?.component).toBe('DatePicker');
+    expect(error?.field).toBe('initialDate');
+    expect(error?.rule).toBe('invalid-format');
+    expect(error?.subcode).toBe('invalid-date-format');
+  });
+
+  test('enforces time format', () => {
+    const error = captureValidationError(<Message>
+      <Actions>
+        <TimePicker actionId="time" initialTime="25:99"/>
+      </Actions>
+    </Message>);
+
+    expect(error?.component).toBe('TimePicker');
+    expect(error?.field).toBe('initialTime');
+    expect(error?.rule).toBe('invalid-format');
+    expect(error?.subcode).toBe('invalid-time-format');
+  });
+});

--- a/xo.config.cjs
+++ b/xo.config.cjs
@@ -74,7 +74,7 @@ const sharedSettings = {
 
 module.exports = [
   {
-    ignores: ['**/*.js', '**/*.cjs', '**/*.mjs', 'tsup.config.ts', 'vitest.config.ts', 'examples/**', 'example/**']
+    ignores: ['**/*.js', '**/*.cjs', '**/*.mjs', 'tsup.config.ts', 'vitest.config.ts', 'examples/**', 'example/**', 'test/fixtures/packed-artifact/**']
   },
   {
     space: true,


### PR DESCRIPTION
## Summary
- enforce Vitest coverage thresholds in CI via a dedicated coverage step
- add table-driven validation conformance tests for the supported validated component surface
- add public export tests and a packed-artifact smoke test for install, type resolution, and JSX runtime behavior

## Testing
- pnpm test
- pnpm run test:coverage
- pnpm run test:smoke