### PR TITLE
Improve documentation and safety guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ const blocks = renderToBlocks(
 
 ### `blockKitBuilderUrl(blocks)`
 
-Returns a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL for the given blocks. Open it in a browser to preview layout and interactivity during development.
+Development helper that returns a [Block Kit Builder](https://app.slack.com/block-kit-builder) URL for the given blocks. Open it in a browser to preview layout and interactivity while working on a payload.
+
+Because the payload is encoded into the URL fragment, very large payloads can produce impractically long URLs. Treat it as a debugging convenience, not a transport format.
 
 ```ts
 import { renderToBlocks, blockKitBuilderUrl } from 'slackblock';
@@ -141,7 +143,7 @@ console.log(blockKitBuilderUrl(blocks));
 
 ### `escapeMrkdwn(text)`
 
-Escapes Slack mrkdwn special characters (`*`, `_`, `~`, `` ` ``, `>`, `&`, `<`, `>`) in a string. Use this when inserting untrusted user content into a mrkdwn text field.
+Escapes Slack mrkdwn special characters in a string. Use it when inserting untrusted user content into mrkdwn text. SlackBlock does not automatically escape every string for you.
 
 ```ts
 import { escapeMrkdwn } from 'slackblock';
@@ -167,43 +169,48 @@ See [docs/validation.md](docs/validation.md) for details.
 
 ## Validation
 
-SlackBlock validates your message against Slack's documented limits and required fields. The `validate` option controls what happens when a violation is detected:
+SlackBlock validates the supported surface against required fields, documented limits, supported format checks, and a small number of structural rules.
 
 | Mode | Behavior |
-|------|----------|
-| `'warn'` (default) | Logs a warning to `console.warn`; rendering continues |
-| `'strict'` | Throws a `SlackblockValidationError` |
-| `'off'` | No validation |
+|---|---|
+| `'warn'` (default) | Logs a warning and continues rendering |
+| `'strict'` | Throws `SlackblockValidationError` |
+| `'off'` | Skips validation entirely |
 
 ```tsx
-// Throw on any violation — recommended for tests
-const message = render(<Message>...</Message>, { validate: 'strict' });
+const message = render(<Message>...</Message>, {validate: 'strict'});
 ```
+
+`SlackblockValidationError` exposes a stable contract: `message`, `path`, `rule`, optional `subcode`, optional `component`, optional `field`, and the normalized `issue` object.
+
+See [docs/validation.md](docs/validation.md) for mode guidance, the error contract, rule categories, and common failures.
+
+---
+
+## Security And Escaping
+
+Slack `mrkdwn` is not plain text, and `<Text>` defaults to mrkdwn. SlackBlock does not automatically escape every string you pass into mrkdwn-capable content.
+
+Use `escapeMrkdwn()` for untrusted or user-generated values:
 
 ```ts
-import { SlackblockValidationError } from 'slackblock';
-
-try {
-  render(<Message>...</Message>, { validate: 'strict' });
-} catch (err) {
-  if (err instanceof SlackblockValidationError) {
-    console.error(err.message); // "Message > Header: Header text exceeds 150 characters."
-    console.error(err.path);    // "Message > Header"
-    console.error(err.rule);    // "too-long"
-    console.error(err.subcode); // "value-too-long"
-  }
-}
+const safe = escapeMrkdwn(userInput);
 ```
 
-Strict mode now catches missing required props and structural gaps across the supported surface, including:
-- missing `actionId` on interactive elements like `TextInput` and `Overflow`
-- missing `externalId` on `<File>`
-- missing `url` / `alt` on `<Image>` and `<ImageLayout>`
-- missing `label` / `element` on `<Input>`
-- incomplete `<Confirmation>` dialogs
-- `<Section>` blocks with neither primary text nor fields
+Use `plainText` when you want Slack `plain_text` semantics instead of mrkdwn formatting. See [docs/security.md](docs/security.md) for the full guidance.
 
-See [docs/validation.md](docs/validation.md) for the stable rule categories and current subcodes.
+---
+
+## Known Differences From Slack
+
+SlackBlock intentionally differs from raw Slack JSON in a few places:
+- it supports an explicit subset of Block Kit rather than the entire Slack surface
+- it uses JSX with `camelCase` props instead of raw `snake_case` JSON
+- `<Text>` defaults to `mrkdwn`, so untrusted text must be escaped explicitly
+- `validate: 'warn'` is the default; invalid input does not always throw
+- `Message.color` uses a legacy attachment wrapper for colored sidebars
+
+See [docs/known-differences.md](docs/known-differences.md) for the longer reference.
 
 ---
 
@@ -277,6 +284,8 @@ If a block, element, or composition object is not listed as `Supported` in the s
 - [Support matrix](docs/support-matrix.md) — current Block Kit coverage
 - [Roadmap](docs/roadmap.md) — tracked gaps and likely next additions
 - [Validation guide](docs/validation.md) — validation modes and error handling
+- [Security and escaping](docs/security.md) — handling untrusted text safely
+- [Known differences](docs/known-differences.md) — behavior that differs from raw Slack JSON
 - [Migrating from jsx-slack](docs/migrating-from-jsx-slack.md)
 - [Migrating from slack-block-builder](docs/migrating-from-slack-block-builder.md)
 - [Slack Block Kit reference](https://api.slack.com/block-kit)

--- a/docs/components.md
+++ b/docs/components.md
@@ -297,6 +297,8 @@ Elements used as props or inside other blocks (not standalone blocks).
 
 Renders a mrkdwn or plain_text text object. Used as the `text` prop on `<Section>`, in `<Context>`, and other places.
 
+`<Text>` defaults to Slack `mrkdwn`. Escape untrusted content with `escapeMrkdwn()` or use `plainText` when you need literal `plain_text` behavior. See [security.md](./security.md).
+
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
 | `children` | `string` | Yes | The text content |

--- a/docs/known-differences.md
+++ b/docs/known-differences.md
@@ -1,0 +1,68 @@
+# Known Differences From Slack
+
+SlackBlock intentionally does not behave like a raw JSON schema wrapper.
+
+## Supported scope is explicit
+
+SlackBlock models a documented subset of Block Kit. New Slack features are not automatically available.
+
+Use these docs as the source of truth:
+- [support-matrix.md](./support-matrix.md)
+- [roadmap.md](./roadmap.md)
+
+## JSX API instead of raw JSON
+
+Slack uses `snake_case` JSON fields. SlackBlock uses JSX components with `camelCase` props.
+
+Examples:
+- `action_id` becomes `actionId`
+- `block_id` becomes `blockId`
+- arrays such as section fields or select options are often expressed as JSX children
+
+## Text behavior is explicit
+
+`<Text>` defaults to Slack `mrkdwn`, not plain text.
+
+That means:
+- formatting is preserved by default
+- untrusted content should be escaped with `escapeMrkdwn()`
+- use `plainText` when you want Slack `plain_text`
+
+## Validation is configurable
+
+SlackBlock does not always throw on invalid input.
+
+Behavior depends on `validate` mode:
+- `'warn'` is the default
+- `'strict'` throws `SlackblockValidationError`
+- `'off'` skips validation entirely
+
+## Unsupported children are skipped outside strict mode
+
+If SlackBlock encounters a JSX child it does not support:
+- `'warn'` logs a warning and continues
+- `'off'` skips it silently
+- `'strict'` throws
+
+## `<Section>` supports a JSX-oriented API
+
+Slack `section` blocks allow text, fields, or both. SlackBlock mirrors that but exposes a JSX-friendly shape:
+- `text` can be a string or `<Text>`
+- `fields` can be passed explicitly
+- field children are also supported for convenience
+- `expand` is supported directly on the component
+
+## `Message.color` uses legacy attachments
+
+SlackBlock supports a convenience `color` prop on `<Message>`. This is not a native Block Kit field.
+
+When used, SlackBlock wraps the rendered blocks in a legacy attachment so Slack can display the colored left border.
+
+## `blockKitBuilderUrl()` is only a preview helper
+
+`blockKitBuilderUrl()` builds a Block Kit Builder URL by encoding your payload into the URL fragment.
+
+That means:
+- it is useful for local debugging and documentation
+- very large payloads can produce impractically long URLs
+- it should not be treated as a production transport or storage format

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,88 @@
+# Security And Escaping
+
+Slack `mrkdwn` is not plain text. Characters like `*`, `_`, `` ` ``, `~`, `<`, and `>` have formatting or parsing meaning inside Slack text objects.
+
+SlackBlock preserves that behavior by default. It does not automatically escape every string you pass into mrkdwn-capable fields.
+
+## When to escape
+
+Escape untrusted or user-generated content before putting it into mrkdwn text.
+
+Examples of content that should usually be escaped:
+- user names or freeform comments inserted into `<Text>`
+- ticket titles, issue names, or commit messages from external systems
+- any string you did not author and do not want Slack formatting to interpret
+
+Use `escapeMrkdwn()`:
+
+```ts
+import {escapeMrkdwn} from 'slackblock';
+
+const safe = escapeMrkdwn(userInput);
+```
+
+## Where escaping matters
+
+These cases usually need escaping when the content is untrusted:
+- `<Text>{userInput}</Text>` because `<Text>` defaults to `mrkdwn`
+- `Section` content that resolves to mrkdwn text
+- any composed string that intentionally uses mrkdwn for the surrounding template but interpolates untrusted values
+
+Example:
+
+```tsx
+import render, {escapeMrkdwn} from 'slackblock';
+import {Message, Section, Text} from 'slackblock/block';
+
+const actor = escapeMrkdwn(user.displayName);
+const comment = escapeMrkdwn(user.comment);
+
+render(
+  <Message text="New comment">
+    <Section text={<Text>{`${actor} said: ${comment}`}</Text>}/>
+  </Message>,
+);
+```
+
+## When escaping is usually unnecessary
+
+`plain_text` fields do not use mrkdwn formatting rules. In SlackBlock, that means content such as:
+- `<Text plainText>{value}</Text>`
+- placeholders
+- input labels and hints
+- button labels
+- confirmation titles, confirm labels, and deny labels
+- header text
+
+Those fields still have their own Slack limits, but mrkdwn escaping is not the main concern there.
+
+## Important limitation
+
+SlackBlock does not try to guess which strings are safe. That is your application's job.
+
+This is intentional:
+- sometimes you want real mrkdwn formatting
+- sometimes you want literal user content
+- automatic escaping would make the formatted case incorrect
+
+If you mix trusted formatting with untrusted values, escape only the untrusted parts.
+
+Bad:
+
+```tsx
+<Text>{`*${userInput}*`}</Text>
+```
+
+Better:
+
+```tsx
+<Text>{`*${escapeMrkdwn(userInput)}*`}</Text>
+```
+
+## Related helpers
+
+`escapeMrkdwn()` is a text-safety helper.
+
+`blockKitBuilderUrl()` is a development helper. It is useful for previewing payloads, but it is not a security boundary and should not be treated as an API transport mechanism.
+
+For broader package behavior differences, see [known-differences.md](./known-differences.md).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,159 +1,198 @@
 # Validation
 
-SlackBlock validates your JSX against Slack's documented limits and required fields before rendering. This catches mistakes early — during development or in tests — rather than at Slack API call time.
+SlackBlock validates supported JSX trees against the Slack rules it currently models: required fields, string length limits, collection limits, date/time formats, and a small number of structural rules.
 
----
-
-## Validation modes
-
-Pass `validate` in the options object to any render function:
+Validation runs in all public render entrypoints:
 
 ```ts
-render(element, { validate: 'strict' });
-renderToMessage(element, { validate: 'strict' });
-renderToBlocks(element, { validate: 'strict' });
+render(element, {validate: 'strict'});
+renderToMessage(element, {validate: 'strict'});
+renderToBlocks(element, {validate: 'strict'});
 ```
 
-| Mode | Default? | Behavior |
-|------|----------|----------|
-| `'warn'` | Yes | Logs a warning via `console.warn`; rendering continues |
-| `'strict'` | — | Throws a `SlackblockValidationError`; rendering halts |
-| `'off'` | — | No validation; no output |
+## Modes
 
-### Choosing a mode
+| Mode | Default? | What happens |
+|---|---|---|
+| `'warn'` | Yes | Rendering continues and SlackBlock logs a warning with component path information |
+| `'strict'` | No | Rendering stops and SlackBlock throws `SlackblockValidationError` |
+| `'off'` | No | SlackBlock skips validation entirely |
 
-- **`'warn'`** — good for production. Violations are logged but don't crash your bot.
-- **`'strict'`** — recommended for tests. Use it to ensure your message templates are valid before deploying.
-- **`'off'`** — use only when you're deliberately constructing payloads that bend the rules or when validation overhead is a concern.
+Use cases:
+- `'warn'`: good default for app runtime when you want visibility without breaking message delivery.
+- `'strict'`: recommended for tests, CI, and template verification.
+- `'off'`: only for cases where you intentionally do not want runtime validation.
 
----
+## Same violation in each mode
 
-## `SlackblockValidationError`
+Given the same invalid payload:
 
-Thrown in `'strict'` mode. Import it for `instanceof` checks:
+```tsx
+<Message>
+  <Actions>
+    <Button actionId={undefined as never}>Approve</Button>
+  </Actions>
+</Message>
+```
+
+`'warn'`:
 
 ```ts
-import { SlackblockValidationError } from 'slackblock';
+render(element, {validate: 'warn'});
+// console.warn("[slackblock] Message > Actions > Button: actionId is required.")
+// render still returns a payload
 ```
 
-### Fields
+`'strict'`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `message` | `string` | Full error message including path (e.g. `"Message > Header: Header text exceeds 150 characters."`) |
-| `path` | `string` | Component path at the point of failure (e.g. `"Message > Header"`) |
-| `rule` | `ValidationRule` | Stable rule category |
-| `subcode` | `string \| undefined` | Optional machine-readable detail |
-| `component` | `string \| undefined` | Component that triggered the issue |
-| `field` | `string \| undefined` | Field associated with the issue when applicable |
-| `issue` | `ValidationIssue` | Full normalized issue object |
+```ts
+render(element, {validate: 'strict'});
+// throws SlackblockValidationError
+```
 
-### Example
+`'off'`:
+
+```ts
+render(element, {validate: 'off'});
+// no warning, no exception
+```
+
+## Error contract
+
+`SlackblockValidationError` is thrown only in `'strict'` mode.
+
+```ts
+import {SlackblockValidationError} from 'slackblock';
+```
+
+Stable fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `message` | `string` | Full message including component path |
+| `path` | `string` | Component path where the issue was detected |
+| `rule` | `ValidationRule` | Stable top-level category |
+| `subcode` | `string \| undefined` | Optional detailed machine-readable code |
+| `component` | `string \| undefined` | Component associated with the issue |
+| `field` | `string \| undefined` | Field associated with the issue |
+| `issue` | `ValidationIssue` | The full normalized issue object |
+
+Current exported types:
+
+```ts
+type ValidationRule =
+  | 'required-field'
+  | 'too-long'
+  | 'too-many'
+  | 'invalid-format'
+  | 'invalid-structure'
+  | 'unsupported-child';
+
+type ValidationIssue = {
+  message: string;
+  path: string;
+  rule: ValidationRule;
+  subcode?: string;
+  component?: string;
+  field?: string;
+};
+```
+
+Example:
 
 ```ts
 try {
   render(
-    <Message text="Hello">
-      <Header text={"x".repeat(200)} />
+    <Message>
+      <Header text={'x'.repeat(200)}/>
     </Message>,
-    { validate: 'strict' }
+    {validate: 'strict'},
   );
-} catch (err) {
-  if (err instanceof SlackblockValidationError) {
-    console.error(err.message);
-    // → "Message > Header: Header text exceeds 150 characters."
+} catch (error) {
+  if (error instanceof SlackblockValidationError) {
+    console.error(error.message);
+    // Message > Header: Header text exceeds 150 characters.
 
-    console.error(err.path);
-    // → "Message > Header"
+    console.error(error.path);
+    // Message > Header
 
-    console.error(err.rule);
-    // → "too-long"
+    console.error(error.rule);
+    // too-long
 
-    console.error(err.subcode);
-    // → "value-too-long"
+    console.error(error.subcode);
+    // value-too-long
   }
 }
 ```
 
----
+## Rule categories
 
-## Rule Categories
-
-SlackBlock now emits stable top-level `rule` categories. When you need detail, inspect `subcode`.
+Use `rule` for stable programmatic branching. Use `subcode` when you need the specific detail.
 
 ### `required-field`
 
-Triggered when a required prop is missing.
+Triggered when a required prop or child is missing.
 
-Example subcodes:
+Common subcodes:
 - `action-id-required`
-- `external-id-required`
+- `elements-required`
+- `options-required`
+- `text-required`
 - `label-required`
 - `element-required`
+- `external-id-required`
+- `url-required`
+- `alt-required`
 - `title-required`
 - `confirm-required`
 - `deny-required`
-- `text-required`
-- `url-required`
-- `alt-required`
-- `options-required`
-- `elements-required`
+
+Example:
 
 ```tsx
-<Button>Submit</Button>
+<Overflow>
+  <Option value="archive">Archive</Option>
+</Overflow>
 // rule: "required-field"
 // subcode: "action-id-required"
 ```
 
 ### `too-long`
 
-Triggered when a string prop exceeds Slack's documented character limit.
+Triggered when a supported string prop exceeds Slack's documented limit.
 
 Current subcode:
 - `value-too-long`
 
-| Component / Prop | Limit |
-|------------------|-------|
-| `Message.text` (hard limit) | 40,000 chars |
-| `Message.text` (recommended) | 4,000 chars |
+Representative limits:
+
+| Field | Limit |
+|---|---|
+| `Message.text` hard limit | 40,000 chars |
+| `Message.text` recommended limit | 4,000 chars |
 | `Header.text` | 150 chars |
-| `Input.label` | 2,000 chars |
-| `Input.hint` | 2,000 chars |
-| `Confirmation.title` | 100 chars |
-| `Confirmation.text` | 300 chars |
-| `Confirmation.confirm` | 30 chars |
-| `Confirmation.deny` | 30 chars |
 | `Button` label | 75 chars |
-| `Button.accessibilityLabel` | 75 chars |
-| `Button.url` | 3,000 chars |
-| `Button.value` | 2,000 chars |
-| `Option` label | 75 chars |
-| `Option.value` | 150 chars |
-| `Option.description` | 75 chars |
-| `Option.url` | 3,000 chars |
-| `OptionGroup.label` | 75 chars |
-| `Image.url` | 3,000 chars |
-| `Image.alt` | 2,000 chars |
-| `Image.title` | 2,000 chars |
+| `Input.label` | 2,000 chars |
+| `Confirmation.text` | 300 chars |
 | `Video.title` | 200 chars |
-| `Video.description` | 200 chars |
-| `Video.authorName` | 50 chars |
-| `blockId` | 255 chars |
 | `actionId` | 255 chars |
+| `blockId` | 255 chars |
 | `placeholder` | 150 chars |
 
 ### `too-many`
 
-Triggered when a collection exceeds Slack's documented count limit.
+Triggered when a supported collection exceeds Slack's documented count limit.
 
 Current subcode:
 - `too-many-items`
 
-| Component / Collection | Limit |
-|------------------------|-------|
-| `Message` blocks | 50 |
-| `Section` fields (children) | 10 |
+Representative limits:
+
+| Collection | Limit |
+|---|---|
+| message blocks | 50 |
 | `Actions` elements | 25 |
+| `Section` fields | 10 |
 | `Context` elements | 10 |
 | `Checkboxes` options | 10 |
 | `RadioGroup` options | 10 |
@@ -164,114 +203,149 @@ Current subcode:
 
 ### `invalid-format`
 
-Triggered when a date or time prop does not match the required format.
+Triggered when a supported formatted prop does not match the expected wire format.
 
 Current subcodes:
 - `invalid-date-format`
 - `invalid-time-format`
 
-| Prop | Required format |
-|------|----------------|
+Supported format checks:
+
+| Field | Required format |
+|---|---|
 | `DatePicker.initialDate` | `YYYY-MM-DD` |
-| `TimePicker.initialTime` | `HH:mm` (24-hour) |
+| `TimePicker.initialTime` | `HH:mm` |
 
 ### `invalid-structure`
 
-Triggered when a supported component is missing one of several acceptable alternatives.
+Triggered when a component requires one of several allowed shapes and none were provided.
 
-Current subcodes:
+Current subcode:
 - `text-or-fields-required`
+
+Example:
+
+```tsx
+<Section />
+// rule: "invalid-structure"
+// subcode: "text-or-fields-required"
+```
 
 ### `unsupported-child`
 
-Triggered when a component is not recognized by SlackBlock's transformer registry.
+Triggered when SlackBlock encounters a JSX child it does not know how to transform.
 
 Current subcode:
 - `unknown-type`
 
-Unrecognized components are silently dropped from the output unless validation is strict.
+In `'warn'` mode SlackBlock warns and continues. In `'off'` mode it silently skips the unsupported child.
 
----
+## Common failures
 
-## Migration Notes
+Missing required field:
 
-If you previously matched against the old granular `error.rule` strings, switch to the stable category in `rule` and use `subcode` for the old detail.
+```tsx
+render(
+  <Message>
+    <Input label="Name" element={<TextInput actionId={undefined as never}/>}/>
+  </Message>,
+  {validate: 'strict'},
+);
+// rule: required-field
+// subcode: action-id-required
+// field: actionId
+```
 
-Examples:
+Length violation:
 
-| Before | After |
+```tsx
+render(
+  <Message>
+    <Header text={'x'.repeat(200)}/>
+  </Message>,
+  {validate: 'strict'},
+);
+// rule: too-long
+// subcode: value-too-long
+```
+
+Count violation:
+
+```tsx
+const options = Array.from({length: 6}, (_, index) => (
+  <Option value={`opt-${index}`}>{`Option ${index}`}</Option>
+));
+
+render(
+  <Message>
+    <Actions>
+      <Overflow actionId="more">{options}</Overflow>
+    </Actions>
+  </Message>,
+  {validate: 'strict'},
+);
+// rule: too-many
+// subcode: too-many-items
+```
+
+Format violation:
+
+```tsx
+render(
+  <Message>
+    <Actions>
+      <DatePicker actionId="date" initialDate="03/07/2026"/>
+    </Actions>
+  </Message>,
+  {validate: 'strict'},
+);
+// rule: invalid-format
+// subcode: invalid-date-format
+// field: initialDate
+```
+
+Structure violation:
+
+```tsx
+render(
+  <Message>
+    <Section />
+  </Message>,
+  {validate: 'strict'},
+);
+// rule: invalid-structure
+// subcode: text-or-fields-required
+```
+
+## Migration note
+
+If you previously matched older granular rule strings directly, switch to the stable category in `rule` and the detailed value in `subcode`.
+
+| Old check | New check |
 |---|---|
-| `error.rule === "action-id-required"` | `error.rule === "required-field" && error.subcode === "action-id-required"` |
-| `error.rule === "value-too-long"` | `error.rule === "too-long" && error.subcode === "value-too-long"` |
-| `error.rule === "too-many-items"` | `error.rule === "too-many" && error.subcode === "too-many-items"` |
-| `error.rule === "invalid-date-format"` | `error.rule === "invalid-format" && error.subcode === "invalid-date-format"` |
-| `error.rule === "unknown-type"` | `error.rule === "unsupported-child" && error.subcode === "unknown-type"` |
+| `error.rule === 'action-id-required'` | `error.rule === 'required-field' && error.subcode === 'action-id-required'` |
+| `error.rule === 'value-too-long'` | `error.rule === 'too-long' && error.subcode === 'value-too-long'` |
+| `error.rule === 'too-many-items'` | `error.rule === 'too-many' && error.subcode === 'too-many-items'` |
+| `error.rule === 'invalid-date-format'` | `error.rule === 'invalid-format' && error.subcode === 'invalid-date-format'` |
+| `error.rule === 'unknown-type'` | `error.rule === 'unsupported-child' && error.subcode === 'unknown-type'` |
 
----
+## Testing recommendation
 
-## Testing with strict mode
-
-Use `validate: 'strict'` in your test suite to catch validation issues early:
+Use `'strict'` mode in tests so invalid templates fail immediately:
 
 ```ts
-import { describe, it, expect } from 'vitest'; // or jest, mocha, etc.
-import render, { SlackblockValidationError } from 'slackblock';
-import { Message, Header } from 'slackblock/block';
+import {expect, test} from 'vitest';
+import render from 'slackblock';
+import {Header, Message} from 'slackblock/block';
 
-describe('my message', () => {
-  it('renders without validation errors', () => {
-    expect(() =>
-      render(
-        <Message text="Hello">
-          <Header text="Welcome" />
-        </Message>,
-        { validate: 'strict' }
-      )
-    ).not.toThrow();
-  });
-
-  it('throws on oversized header', () => {
-    expect(() =>
-      render(
-        <Message text="Hello">
-          <Header text={"x".repeat(200)} />
-        </Message>,
-        { validate: 'strict' }
-      )
-    ).toThrow(SlackblockValidationError);
-  });
+test('message template stays valid', () => {
+  expect(() => render(
+    <Message text="Hello">
+      <Header text="Welcome"/>
+    </Message>,
+    {validate: 'strict'},
+  )).not.toThrow();
 });
 ```
 
----
-
-## `escapeMrkdwn`
-
-A utility for safely inserting untrusted user content into mrkdwn text fields.
-
-```ts
-import { escapeMrkdwn } from 'slackblock';
-```
-
-Escapes the following characters:
-- `&` → `&amp;`
-- `<` → `&lt;`
-- `>` → `&gt;`
-- `*`, `_`, `~`, `` ` `` → prepended with a zero-width space to prevent formatting
-
-### Example
-
-```tsx
-import render, { escapeMrkdwn } from 'slackblock';
-import { Message, Section, Text } from 'slackblock/block';
-
-const userComment = 'Hello *world* <script>';
-const safe = escapeMrkdwn(userComment);
-// → "Hello \u200B*world\u200B* &lt;script&gt;"
-
-render(
-  <Message text="New comment">
-    <Section text={<Text>{safe}</Text>} />
-  </Message>
-);
-```
+For escaping and untrusted text handling, see [security.md](./security.md).

--- a/src/utils/block-kit-builder.ts
+++ b/src/utils/block-kit-builder.ts
@@ -1,8 +1,9 @@
 import {type Block} from '../constants/types';
 
 /**
- * Returns a Slack Block Kit Builder URL for previewing the given blocks.
- * Open the URL in a browser to inspect layout and interactivity.
+ * Development helper that returns a Slack Block Kit Builder URL for previewing
+ * the given blocks. The full payload is encoded into the URL fragment, so very
+ * large payloads can produce impractically long URLs.
  */
 export const blockKitBuilderUrl = (blocks: Block[]): string =>
   `https://app.slack.com/block-kit-builder#${JSON.stringify({blocks})}`;

--- a/src/utils/escape-mrkdwn.ts
+++ b/src/utils/escape-mrkdwn.ts
@@ -1,6 +1,7 @@
 /**
  * Escapes Slack mrkdwn special characters in a string to prevent unintended
- * formatting. Use this when inserting untrusted user content into mrkdwn fields.
+ * formatting. Use this for untrusted content that will be inserted into mrkdwn
+ * fields. SlackBlock does not automatically escape every string for you.
  *
  * Escapes: `&` `<` `>` `*` `_` `~` `` ` ``
  *


### PR DESCRIPTION
## Summary
- rewrite the validation guide around the current mode behavior and normalized error contract
- add dedicated security and escaping guidance for mrkdwn and untrusted text
- document known differences from raw Slack JSON and clarify helper limitations in the README

## Testing
- pnpm run test:lint