### PR TITLE
Add warn-mode validation reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Both `render` / `renderToMessage` / `renderToBlocks` accept an optional `options
 ```ts
 type RenderOptions = {
   validate?: 'off' | 'warn' | 'strict'; // default: 'warn'
+  onValidation?: (issue: ValidationIssue) => void; // optional warn-mode reporter
   channel?: string; // included in the payload; narrows return type to SlackPostMessagePayload
   user?: string;    // requires channel; narrows return type to SlackPostEphemeralPayload
 };
@@ -182,6 +183,15 @@ const message = render(<Message>...</Message>, {validate: 'strict'});
 ```
 
 `SlackblockValidationError` exposes a stable contract: `message`, `path`, `rule`, optional `subcode`, optional `component`, optional `field`, and the normalized `issue` object.
+
+For structured logging in warn mode, pass `onValidation`:
+
+```ts
+render(<Message>...</Message>, {
+  validate: 'warn',
+  onValidation: issue => logger.warn(issue),
+});
+```
 
 See [docs/validation.md](docs/validation.md) for mode guidance, the error contract, rule categories, and common failures.
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -95,6 +95,7 @@ Status meanings:
 | `renderToMessage()` | Supported | Named alias of `render()` |
 | `renderToBlocks()` | Supported | Block-array renderer for modals/home tabs |
 | Validation modes | Supported | `off`, `warn`, `strict` |
+| Warn-mode validation reporter | Supported | `RenderOptions.onValidation` |
 | `SlackblockValidationError` | Supported | Stable rule categories with optional subcodes |
 | `escapeMrkdwn()` | Supported | Escapes untrusted mrkdwn input |
 | `blockKitBuilderUrl()` | Supported | Builder preview URL generator |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -14,7 +14,7 @@ renderToBlocks(element, {validate: 'strict'});
 
 | Mode | Default? | What happens |
 |---|---|---|
-| `'warn'` | Yes | Rendering continues and SlackBlock logs a warning with component path information |
+| `'warn'` | Yes | Rendering continues and SlackBlock logs a warning with component path information, or calls `onValidation` if provided |
 | `'strict'` | No | Rendering stops and SlackBlock throws `SlackblockValidationError` |
 | `'off'` | No | SlackBlock skips validation entirely |
 
@@ -22,6 +22,27 @@ Use cases:
 - `'warn'`: good default for app runtime when you want visibility without breaking message delivery.
 - `'strict'`: recommended for tests, CI, and template verification.
 - `'off'`: only for cases where you intentionally do not want runtime validation.
+
+## Warn-mode reporter hook
+
+If you want warn-mode issues to flow into your own logger instead of `console.warn`, pass `onValidation` in the render options.
+
+```ts
+import render from 'slackblock';
+
+render(element, {
+  validate: 'warn',
+  onValidation: issue => logger.warn(issue),
+});
+```
+
+The hook receives the normalized `ValidationIssue` object.
+
+Notes:
+- `onValidation` is only used in warn mode
+- if `onValidation` is omitted, SlackBlock falls back to `console.warn`
+- `strict` still throws
+- `off` still suppresses validation entirely
 
 ## Same violation in each mode
 
@@ -40,6 +61,17 @@ Given the same invalid payload:
 ```ts
 render(element, {validate: 'warn'});
 // console.warn("[slackblock] Message > Actions > Button: actionId is required.")
+// render still returns a payload
+```
+
+With a custom reporter:
+
+```ts
+render(element, {
+  validate: 'warn',
+  onValidation: issue => logger.warn(issue),
+});
+// your logger receives the ValidationIssue object
 // render still returns a payload
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export {
   type SerializedElement,
   type SerializedOption,
 } from './constants/types';
-export {type ValidationMode} from './utils/validation-context';
+export {type ValidationMode, type ValidationReporter} from './utils/validation-context';
 export {
   SlackblockValidationError,
   type ValidationIssue,

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -7,7 +7,7 @@ import parser from '../parser';
 import getType from '../utils/get-type';
 import {warnIfTooMany, warnIfTooLong} from '../utils/validation';
 import {
-  initContext, pushPath, popPath, type ValidationMode,
+  initContext, pushPath, popPath, type ValidationMode, type ValidationReporter,
 } from '../utils/validation-context';
 import {MAX_BLOCKS, MAX_MESSAGE_TEXT, RECOMMENDED_MESSAGE_TEXT} from '../constants/limits';
 
@@ -18,13 +18,21 @@ import {MAX_BLOCKS, MAX_MESSAGE_TEXT, RECOMMENDED_MESSAGE_TEXT} from '../constan
  *   - `'warn'`   — log warnings via `console.warn` (default)
  *   - `'strict'` — throw `SlackblockValidationError` on any violation
  *   - `'off'`    — disable validation entirely
+ * @property onValidation - Optional warn-mode hook. When provided alongside
+ *   warn mode, SlackBlock calls this reporter with the normalized issue
+ *   instead of writing to `console.warn`.
  * @property channel - When provided, the result includes `channel` and is typed
  *   as `SlackPostMessagePayload` (directly usable with `chat.postMessage`).
  * @property user - When provided alongside `channel`, the result is typed as
  *   `SlackPostEphemeralPayload` (directly usable with `chat.postEphemeral`).
  *   Has no effect without `channel`.
  */
-export type RenderOptions = {validate?: ValidationMode; channel?: string; user?: string};
+export type RenderOptions = {
+  validate?: ValidationMode;
+  onValidation?: ValidationReporter;
+  channel?: string;
+  user?: string;
+};
 
 /**
  * Renders JSX children directly to a `Block[]` array, without requiring a
@@ -32,7 +40,7 @@ export type RenderOptions = {validate?: ValidationMode; channel?: string; user?:
  * accept a blocks array rather than a full message payload.
  */
 export const renderToBlocks = (element: Child, options?: RenderOptions): Block[] => {
-  initContext(options?.validate ?? 'warn');
+  initContext(options?.validate ?? 'warn', options?.onValidation);
   // Unwrap top-level fragments so the parser receives their children directly.
   const child: Child
     = typeof element === 'object'
@@ -104,7 +112,7 @@ function render(element: Element, options: RenderOptions & {channel: string; use
 function render(element: Element, options: RenderOptions & {channel: string}): SlackPostMessagePayload;
 function render(element: Element, options?: RenderOptions): BoltCompatiblePayload;
 function render(element: Element, options?: RenderOptions): SlackMessageDraft {
-  initContext(options?.validate ?? 'warn');
+  initContext(options?.validate ?? 'warn', options?.onValidation);
 
   const properties = element.props as MessageProperties;
 

--- a/src/utils/validation-context.ts
+++ b/src/utils/validation-context.ts
@@ -8,20 +8,24 @@ import {SlackblockValidationError, type ValidationIssue, type ValidationRule} fr
  * - `'off'`    — suppress all validation
  */
 export type ValidationMode = 'off' | 'warn' | 'strict';
+export type ValidationReporter = (issue: ValidationIssue) => void;
 
 type ValidationContext = {
   mode: ValidationMode;
   path: string[];
+  reporter?: ValidationReporter;
 };
 
 const context: ValidationContext = {
   mode: 'warn',
   path: [],
+  reporter: undefined,
 };
 
-export const initContext = (mode: ValidationMode): void => {
+export const initContext = (mode: ValidationMode, reporter?: ValidationReporter): void => {
   context.mode = mode;
   context.path = [];
+  context.reporter = reporter;
 };
 
 export const pushPath = (segment: string): void => {
@@ -68,7 +72,12 @@ export const report = (input: ReportInput): void => {
   const issue = toIssue(input);
 
   if (context.mode === 'warn') {
-    console.warn(`[slackblock] ${issue.path}: ${issue.message}`);
+    if (context.reporter) {
+      context.reporter(issue);
+    } else {
+      console.warn(`[slackblock] ${issue.path}: ${issue.message}`);
+    }
+
     return;
   }
 

--- a/test/public-api/exports.test.ts
+++ b/test/public-api/exports.test.ts
@@ -6,6 +6,7 @@ import render, {
   escapeMrkdwn,
   renderToBlocks,
   renderToMessage,
+  type ValidationReporter,
 } from '../../src';
 import * as block from '../../src/block';
 import * as jsxDevRuntime from '../../src/jsx-dev-runtime';
@@ -18,6 +19,14 @@ test('root entrypoint exports renderer and helpers', () => {
   expect(escapeMrkdwn).toBeTypeOf('function');
   expect(blockKitBuilderUrl).toBeTypeOf('function');
   expect(SlackblockValidationError).toBeTypeOf('function');
+});
+
+test('root entrypoint exports validation reporter type compatibility', () => {
+  const reporter: ValidationReporter = issue => {
+    expect(issue.rule).toBeTypeOf('string');
+  };
+
+  expect(reporter).toBeTypeOf('function');
 });
 
 test('block entrypoint exports the public component barrel', () => {

--- a/test/renderer/render-to-blocks.test.tsx
+++ b/test/renderer/render-to-blocks.test.tsx
@@ -1,7 +1,8 @@
-import {test, expect} from 'vitest';
+import {test, expect, vi} from 'vitest';
 
 import Divider from '../../src/components/layout/divider';
 import Header from '../../src/components/layout/header';
+import {type ValidationIssue} from '../../src/errors';
 import {renderToBlocks} from '../../src/renderer';
 
 test('returns Block[] from a JSX element without a <Message> wrapper', () => {
@@ -33,6 +34,18 @@ test('passes validate option through — strict mode throws on unknown types', (
   const render = () => renderToBlocks(<div/>, {validate: 'strict'});
 
   expect(render).toThrow();
+});
+
+test('passes onValidation through in warn mode', () => {
+  const onValidation = vi.fn<(issue: ValidationIssue) => void>();
+
+  const blocks = renderToBlocks(<div/>, {validate: 'warn', onValidation});
+
+  expect(blocks).toEqual([]);
+  expect(onValidation).toHaveBeenCalledWith(expect.objectContaining({
+    rule: 'unsupported-child',
+    subcode: 'unknown-type',
+  }));
 });
 
 test('works with a single element (no fragment)', () => {

--- a/test/validation/validation.test.tsx
+++ b/test/validation/validation.test.tsx
@@ -8,6 +8,7 @@ import {
 
 import render, {
   type RenderOptions,
+  type ValidationIssue,
   SlackblockValidationError,
   escapeMrkdwn,
 } from '../../src';
@@ -75,6 +76,20 @@ describe('off mode', () => {
         </Message>,
         {validate: 'off'},
       )).not.toThrow();
+  });
+
+  test('does not call onValidation in off mode', () => {
+    const onValidation = vi.fn<(issue: ValidationIssue) => void>();
+
+    expect(() =>
+      render(
+        <Message>
+          <Header text={longHeaderText}/>
+        </Message>,
+        {validate: 'off', onValidation},
+      )).not.toThrow();
+
+    expect(onValidation).not.toHaveBeenCalled();
   });
 });
 
@@ -170,6 +185,53 @@ describe('warn mode', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[slackblock]'));
     consoleSpy.mockRestore();
   });
+
+  test('uses onValidation reporter instead of console.warn when provided', () => {
+    const onValidation = vi.fn<(issue: ValidationIssue) => void>();
+
+    expect(() =>
+      render(
+        <Message>
+          <Header text={longHeaderText}/>
+        </Message>,
+        {onValidation},
+      )).not.toThrow();
+
+    expect(onValidation).toHaveBeenCalledTimes(1);
+    expect(onValidation).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'Message > Header',
+      rule: 'too-long',
+      subcode: 'value-too-long',
+      component: 'Header',
+    }));
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('passes normalized issues to onValidation reporter', () => {
+    const onValidation = vi.fn<(issue: ValidationIssue) => void>();
+
+    expect(() =>
+      render(
+        <Message>
+          <Actions>
+            {/* @ts-expect-error - intentionally omit actionId */}
+            <Button actionId={undefined}>Click</Button>
+          </Actions>
+        </Message>,
+        {validate: 'warn', onValidation},
+      )).not.toThrow();
+
+    expect(onValidation).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'Message > Actions > Button',
+      rule: 'required-field',
+      subcode: 'action-id-required',
+      field: 'actionId',
+      component: 'Button',
+    }));
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
 });
 
 // ─── strict mode ────────────────────────────────────────────────────────────
@@ -221,6 +283,20 @@ describe('strict mode', () => {
         </Message>,
         {validate: 'strict'},
       )).toThrow(SlackblockValidationError);
+  });
+
+  test('does not call onValidation in strict mode', () => {
+    const onValidation = vi.fn<(issue: ValidationIssue) => void>();
+
+    expect(() =>
+      render(
+        <Message>
+          <Header text={longHeaderText}/>
+        </Message>,
+        {validate: 'strict', onValidation},
+      )).toThrow(SlackblockValidationError);
+
+    expect(onValidation).not.toHaveBeenCalled();
   });
 
   test('error.rule is normalized for length violation', () => {


### PR DESCRIPTION
## Summary
- add `RenderOptions.onValidation` so warn-mode validation issues can be routed into structured logging
- keep strict and off mode behavior unchanged while applying the hook to both `render()` and `renderToBlocks()`
- add tests and docs covering the new reporter hook and its normalized `ValidationIssue` payloads

## Testing
- pnpm test
