### PR TITLE
Brand internal components in parser

### DIFF
--- a/.changeset/swift-mirrors-write.md
+++ b/.changeset/swift-mirrors-write.md
@@ -1,0 +1,5 @@
+---
+"slackblock": minor
+---
+
+Brand internal components so the parser only transforms SlackBlock-owned JSX elements. Unbranded lookalike components are now ignored consistently, including when nested in block, input, and rich text children.

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -1,0 +1,28 @@
+const slackComponentBrand = Symbol('slackblock.component');
+
+type AbstractConstructor<T = Record<string, unknown>> = abstract new (...parameters: unknown[]) => T;
+
+export type SlackComponentType<
+  TProps = Record<string, unknown>,
+  TSlackType extends string = string,
+> = AbstractConstructor<{props: TProps}> & {
+  readonly [slackComponentBrand]: true;
+  slackType: TSlackType;
+};
+
+export type SlackElement<TComponent extends SlackComponentType = SlackComponentType> = JSX.Element & {
+  type: TComponent;
+  props: InstanceType<TComponent>['props'];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export abstract class SlackComponent {
+  // eslint-disable-next-line @typescript-eslint/class-literal-property-style
+  static readonly [slackComponentBrand] = true;
+}
+
+export const isSlackComponentType = (value: unknown): value is SlackComponentType =>
+  typeof value === 'function'
+  && value !== null
+  && (value as unknown as Record<PropertyKey, unknown>)[slackComponentBrand] === true
+  && typeof (value as {slackType?: unknown}).slackType === 'string';

--- a/src/components/block/button.tsx
+++ b/src/components/block/button.tsx
@@ -1,3 +1,5 @@
+import {SlackComponent} from '../base';
+import {type ConfirmationElement} from '../../constants/types';
 
 type TopProperties = {
   children: string;
@@ -9,7 +11,7 @@ type TopProperties = {
 };
 
 export type ButtonProps = TopProperties & {
-  confirm?: JSX.Element;
+  confirm?: ConfirmationElement;
 };
 
 type Properties = ButtonProps;
@@ -25,7 +27,7 @@ type Properties = ButtonProps;
  * <Button actionId="docs" url="https://example.com">View docs</Button>
  * ```
  */
-export default class Button {
+export default class Button extends SlackComponent {
   static slackType = 'Button';
   declare props: Properties;
 }

--- a/src/components/block/confirmation.tsx
+++ b/src/components/block/confirmation.tsx
@@ -1,3 +1,5 @@
+import {SlackComponent} from '../base';
+import {type TextElement} from '../../constants/types';
 
 type TopProperties = {
   title: string;
@@ -7,7 +9,7 @@ type TopProperties = {
 
 /* This is a dumb workaround to merging props */
 export type ConfirmationProps = TopProperties & {
-  children: JSX.Element;
+  children: TextElement;
 };
 
 type Properties = ConfirmationProps;
@@ -29,7 +31,7 @@ type Properties = ConfirmationProps;
  * <Button actionId="delete" confirm={dialog} style="danger">Delete</Button>
  * ```
  */
-export default class Confirmation {
+export default class Confirmation extends SlackComponent {
   static slackType = 'Confirmation';
   declare props: Properties;
 }

--- a/src/components/block/image.tsx
+++ b/src/components/block/image.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   url: string;
@@ -18,7 +19,7 @@ export type Props = {
  * </Context>
  * ```
  */
-export default class Image {
+export default class Image extends SlackComponent {
   static slackType = 'Image';
   declare props: Props;
 }

--- a/src/components/block/text.tsx
+++ b/src/components/block/text.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   children: string;
@@ -18,7 +19,7 @@ export type Props = {
  * <Text plainText emoji>Hello :wave:</Text>
  * ```
  */
-export default class Text {
+export default class Text extends SlackComponent {
   static slackType = 'Text';
   declare props: Props;
 }

--- a/src/components/input/checkboxes.tsx
+++ b/src/components/input/checkboxes.tsx
@@ -1,11 +1,12 @@
-
+import {SlackComponent} from '../base';
+import {type ConfirmationElement, type OptionElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<JSX.Element>;
-  initialOptions?: JSX.Element[];
-  confirm?: JSX.Element;
+  children: SingleOrArray<OptionElement>;
+  initialOptions?: OptionElement[];
+  confirm?: ConfirmationElement;
   focusOnLoad?: boolean;
 };
 
@@ -22,7 +23,7 @@ export type Props = {
  * </Checkboxes>
  * ```
  */
-export default class Checkboxes {
+export default class Checkboxes extends SlackComponent {
   static slackType = 'Checkboxes';
   declare props: Props;
 }

--- a/src/components/input/date-picker.tsx
+++ b/src/components/input/date-picker.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   actionId: string;
@@ -19,7 +20,7 @@ export type Props = {
  * } />
  * ```
  */
-export default class DatePicker {
+export default class DatePicker extends SlackComponent {
   static slackType = 'DatePicker';
   declare props: Props;
 }

--- a/src/components/input/date-time-picker.tsx
+++ b/src/components/input/date-time-picker.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   actionId: string;
@@ -18,7 +19,7 @@ export type Props = {
  * } />
  * ```
  */
-export default class DateTimePicker {
+export default class DateTimePicker extends SlackComponent {
   static slackType = 'DateTimePicker';
   declare props: Props;
 }

--- a/src/components/input/option-group.tsx
+++ b/src/components/input/option-group.tsx
@@ -1,7 +1,9 @@
+import {SlackComponent} from '../base';
+import {type OptionElement} from '../../constants/types';
 
 export type Props = {
   label: string;
-  children: JSX.Element | JSX.Element[];
+  children: OptionElement | OptionElement[];
 };
 
 /**
@@ -16,7 +18,7 @@ export type Props = {
  * </Select>
  * ```
  */
-export default class OptionGroup {
+export default class OptionGroup extends SlackComponent {
   static slackType = 'OptionGroup';
   declare props: Props;
 }

--- a/src/components/input/option.tsx
+++ b/src/components/input/option.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   children: string;
@@ -16,7 +17,7 @@ export type Props = {
  * <Option value="opt_a" description="The first option">Option A</Option>
  * ```
  */
-export default class Option {
+export default class Option extends SlackComponent {
   static slackType = 'Option';
   declare props: Props;
 }

--- a/src/components/input/overflow.tsx
+++ b/src/components/input/overflow.tsx
@@ -1,10 +1,11 @@
-
+import {SlackComponent} from '../base';
+import {type ConfirmationElement, type OptionElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<JSX.Element>;
-  confirm?: JSX.Element;
+  children: SingleOrArray<OptionElement>;
+  confirm?: ConfirmationElement;
 };
 
 /**
@@ -21,7 +22,7 @@ export type Props = {
  * </Overflow>
  * ```
  */
-export default class Overflow {
+export default class Overflow extends SlackComponent {
   static slackType = 'Overflow';
   declare props: Props;
 }

--- a/src/components/input/radio-group.tsx
+++ b/src/components/input/radio-group.tsx
@@ -1,11 +1,12 @@
-
+import {SlackComponent} from '../base';
+import {type ConfirmationElement, type OptionElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
   actionId: string;
-  children: SingleOrArray<JSX.Element>;
-  initialOption?: JSX.Element;
-  confirm?: JSX.Element;
+  children: SingleOrArray<OptionElement>;
+  initialOption?: OptionElement;
+  confirm?: ConfirmationElement;
   focusOnLoad?: boolean;
 };
 
@@ -23,7 +24,7 @@ export type Props = {
  * </RadioGroup>
  * ```
  */
-export default class RadioGroup {
+export default class RadioGroup extends SlackComponent {
   static slackType = 'RadioGroup';
   declare props: Props;
 }

--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -1,4 +1,5 @@
-
+import {SlackComponent} from '../base';
+import {type ConfirmationElement, type OptionElement, type OptionGroupElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export const selectTypes = {
@@ -22,9 +23,9 @@ export type Props = {
   actionId: string;
   type?: SelectType;
   multi?: boolean;
-  children?: SingleOrArray<JSX.Element>;
-  initialOptions?: JSX.Element[];
-  confirm?: JSX.Element;
+  children?: SingleOrArray<OptionElement>;
+  initialOptions?: OptionElement[];
+  confirm?: ConfirmationElement;
   maxSelectedItems?: number;
   minQueryLength?: number;
   focusOnLoad?: boolean;
@@ -55,7 +56,7 @@ export type Props = {
  * <Select type="user" multi placeholder="Pick users" actionId="mentions" />
  * ```
  */
-export default class Select {
+export default class Select extends SlackComponent {
   static slackType = 'Select';
   declare props: Props;
 }

--- a/src/components/input/select.tsx
+++ b/src/components/input/select.tsx
@@ -1,5 +1,5 @@
 import {SlackComponent} from '../base';
-import {type ConfirmationElement, type OptionElement, type OptionGroupElement} from '../../constants/types';
+import {type ConfirmationElement, type OptionElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export const selectTypes = {

--- a/src/components/input/text.tsx
+++ b/src/components/input/text.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   actionId: string;
@@ -27,7 +28,7 @@ export type Props = {
  * } />
  * ```
  */
-export default class TextInput {
+export default class TextInput extends SlackComponent {
   static slackType = 'TextInput';
   declare props: Props;
 }

--- a/src/components/input/time-picker.tsx
+++ b/src/components/input/time-picker.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   actionId: string;
@@ -19,7 +20,7 @@ export type Props = {
  * } />
  * ```
  */
-export default class TimePicker {
+export default class TimePicker extends SlackComponent {
   static slackType = 'TimePicker';
   declare props: Props;
 }

--- a/src/components/layout/actions.tsx
+++ b/src/components/layout/actions.tsx
@@ -1,4 +1,4 @@
-
+import {SlackComponent} from '../base';
 import {type InteractiveBlockElement} from '../../constants/types';
 
 export type Props = {
@@ -20,7 +20,7 @@ export type Props = {
  * </Actions>
  * ```
  */
-export default class Actions {
+export default class Actions extends SlackComponent {
   static slackType = 'Actions';
   declare props: Props;
 }

--- a/src/components/layout/container.tsx
+++ b/src/components/layout/container.tsx
@@ -1,4 +1,4 @@
-
+import {SlackComponent} from '../base';
 import {type SingleOrArray} from '../../utils/type-helpers';
 import {type Child} from '../../constants/types';
 
@@ -23,7 +23,7 @@ export type Props = {
  * </Message>
  * ```
  */
-export default class Container {
+export default class Container extends SlackComponent {
   static slackType = 'Container';
   declare props: Props;
 }

--- a/src/components/layout/context.tsx
+++ b/src/components/layout/context.tsx
@@ -1,5 +1,7 @@
+import {SlackComponent} from '../base';
+import {type ContextElement} from '../../constants/types';
 
-export type ImageOrText = JSX.Element;
+export type ImageOrText = ContextElement;
 
 export type Props = {
   children: ImageOrText | ImageOrText[];
@@ -19,7 +21,7 @@ export type Props = {
  * </Context>
  * ```
  */
-export default class Context {
+export default class Context extends SlackComponent {
   static slackType = 'Context';
   declare props: Props;
 }

--- a/src/components/layout/divider.tsx
+++ b/src/components/layout/divider.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   blockId?: string;
@@ -11,7 +12,7 @@ export type Props = {
  * <Divider />
  * ```
  */
-export default class Divider {
+export default class Divider extends SlackComponent {
   static slackType = 'Divider';
   declare props: Props;
 }

--- a/src/components/layout/file.tsx
+++ b/src/components/layout/file.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   externalId: string;
@@ -12,7 +13,7 @@ export type Props = {
  * <File externalId="my-report-id" />
  * ```
  */
-export default class File {
+export default class File extends SlackComponent {
   static slackType = 'File';
   declare props: Props;
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   text: string;
@@ -15,7 +16,7 @@ export type Props = {
  * <Header text="Deploy complete" emoji />
  * ```
  */
-export default class Header {
+export default class Header extends SlackComponent {
   static slackType = 'Header';
   declare props: Props;
 }

--- a/src/components/layout/image.tsx
+++ b/src/components/layout/image.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   url: string;
@@ -22,7 +23,7 @@ export type Props = {
  * />
  * ```
  */
-export default class Image {
+export default class Image extends SlackComponent {
   static slackType = 'ImageLayout';
   declare props: Props;
 }

--- a/src/components/layout/input.tsx
+++ b/src/components/layout/input.tsx
@@ -1,4 +1,4 @@
-
+import {SlackComponent} from '../base';
 import {type InputBlockElement} from '../../constants/types';
 
 export type Props = {
@@ -23,7 +23,7 @@ export type Props = {
  * />
  * ```
  */
-export default class Input {
+export default class Input extends SlackComponent {
   static slackType = 'Input';
   declare props: Props;
 }

--- a/src/components/layout/rich-text.tsx
+++ b/src/components/layout/rich-text.tsx
@@ -1,11 +1,12 @@
-
+import {SlackComponent} from '../base';
+import {type RichTextBlockChild} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type RichTextElement = Record<string, unknown>;
 
 export type Props = {
   elements?: RichTextElement[];
-  children?: SingleOrArray<JSX.Element | string>;
+  children?: SingleOrArray<RichTextBlockChild>;
   blockId?: string;
 };
 
@@ -25,7 +26,7 @@ export type Props = {
  * </RichText>
  * ```
  */
-export default class RichText {
+export default class RichText extends SlackComponent {
   static slackType = 'RichText';
   declare props: Props;
 }

--- a/src/components/layout/section.tsx
+++ b/src/components/layout/section.tsx
@@ -1,12 +1,12 @@
-
-import {type BlockElement} from '../../constants/types';
+import {SlackComponent} from '../base';
+import {type BlockElement, type TextElement} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
-type TextElement = JSX.Element | string;
-type FieldElement = JSX.Element | string;
+type SectionTextValue = TextElement | string;
+type FieldElement = TextElement | string;
 
 export type Props = {
-  text?: TextElement;
+  text?: SectionTextValue;
   // eslint-disable-next-line @typescript-eslint/no-restricted-types -- We actually want to handle null fields
   fields?: SingleOrArray<FieldElement | null | undefined | false>;
   blockId?: string;
@@ -40,7 +40,7 @@ export type Props = {
  * <Section expand fields={<Text>Status</Text>} />
  * ```
  */
-export default class Section {
+export default class Section extends SlackComponent {
   static slackType = 'Section';
   declare props: Props;
 }

--- a/src/components/layout/video.tsx
+++ b/src/components/layout/video.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   title: string;
@@ -26,7 +27,7 @@ export type Props = {
  * />
  * ```
  */
-export default class Video {
+export default class Video extends SlackComponent {
   static slackType = 'Video';
   declare props: Props;
 }

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -1,5 +1,6 @@
-
 import {type Child} from '../constants/types';
+
+import {SlackComponent} from './base';
 
 /**
  * Props for the `<Message>` component.
@@ -40,7 +41,7 @@ export type Properties = {
  * );
  * ```
  */
-export default class Message {
+export default class Message extends SlackComponent {
   static slackType = 'Message';
   declare props: Properties;
 }

--- a/src/components/rich-text/broadcast.tsx
+++ b/src/components/rich-text/broadcast.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 import {type RichTextBroadcastRange} from './types';
 
@@ -13,7 +14,7 @@ export type Props = {
  * <RichTextBroadcast range="here" />
  * ```
  */
-export default class RichTextBroadcast {
+export default class RichTextBroadcast extends SlackComponent {
   static slackType = 'RichTextBroadcast';
   declare props: Props;
 }

--- a/src/components/rich-text/channel.tsx
+++ b/src/components/rich-text/channel.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   channelId: string;
@@ -11,7 +12,7 @@ export type Props = {
  * <RichTextChannel channelId="C123456" />
  * ```
  */
-export default class RichTextChannel {
+export default class RichTextChannel extends SlackComponent {
   static slackType = 'RichTextChannel';
   declare props: Props;
 }

--- a/src/components/rich-text/date.tsx
+++ b/src/components/rich-text/date.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   timestamp: number;
@@ -22,7 +23,7 @@ export type Props = {
  * />
  * ```
  */
-export default class RichTextDate {
+export default class RichTextDate extends SlackComponent {
   static slackType = 'RichTextDate';
   declare props: Props;
 }

--- a/src/components/rich-text/emoji.tsx
+++ b/src/components/rich-text/emoji.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   name: string;
@@ -11,7 +12,7 @@ export type Props = {
  * <RichTextEmoji name="wave" />
  * ```
  */
-export default class RichTextEmoji {
+export default class RichTextEmoji extends SlackComponent {
   static slackType = 'RichTextEmoji';
   declare props: Props;
 }

--- a/src/components/rich-text/link.tsx
+++ b/src/components/rich-text/link.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 import {type RichTextStyle} from './types';
 
@@ -16,7 +17,7 @@ export type Props = {
  * <RichTextLink url="https://example.com" style={{ bold: true }}>Visit us</RichTextLink>
  * ```
  */
-export default class RichTextLink {
+export default class RichTextLink extends SlackComponent {
   static slackType = 'RichTextLink';
   declare props: Props;
 }

--- a/src/components/rich-text/list.tsx
+++ b/src/components/rich-text/list.tsx
@@ -1,11 +1,12 @@
-
+import {SlackComponent} from '../base';
+import {type RichTextInlineChild} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 import {type RichTextListStyle} from './types';
 
 export type Props = {
   style: RichTextListStyle;
-  children: SingleOrArray<JSX.Element | string>;
+  children: SingleOrArray<RichTextInlineChild>;
   indent?: number;
   border?: number;
 };
@@ -24,7 +25,7 @@ export type Props = {
  * </RichTextList>
  * ```
  */
-export default class RichTextList {
+export default class RichTextList extends SlackComponent {
   static slackType = 'RichTextList';
   declare props: Props;
 }

--- a/src/components/rich-text/preformatted.tsx
+++ b/src/components/rich-text/preformatted.tsx
@@ -1,8 +1,9 @@
-
+import {SlackComponent} from '../base';
+import {type RichTextInlineChild} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<JSX.Element | string>;
+  children: SingleOrArray<RichTextInlineChild>;
 };
 
 /**
@@ -15,7 +16,7 @@ export type Props = {
  * </RichTextPreformatted>
  * ```
  */
-export default class RichTextPreformatted {
+export default class RichTextPreformatted extends SlackComponent {
   static slackType = 'RichTextPreformatted';
   declare props: Props;
 }

--- a/src/components/rich-text/quote.tsx
+++ b/src/components/rich-text/quote.tsx
@@ -1,8 +1,9 @@
-
+import {SlackComponent} from '../base';
+import {type RichTextInlineChild} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<JSX.Element | string>;
+  children: SingleOrArray<RichTextInlineChild>;
 };
 
 /**
@@ -15,7 +16,7 @@ export type Props = {
  * </RichTextQuote>
  * ```
  */
-export default class RichTextQuote {
+export default class RichTextQuote extends SlackComponent {
   static slackType = 'RichTextQuote';
   declare props: Props;
 }

--- a/src/components/rich-text/section.tsx
+++ b/src/components/rich-text/section.tsx
@@ -1,8 +1,9 @@
-
+import {SlackComponent} from '../base';
+import {type RichTextInlineChild} from '../../constants/types';
 import {type SingleOrArray} from '../../utils/type-helpers';
 
 export type Props = {
-  children: SingleOrArray<JSX.Element | string>;
+  children: SingleOrArray<RichTextInlineChild>;
 };
 
 /**
@@ -17,7 +18,7 @@ export type Props = {
  * </RichTextSection>
  * ```
  */
-export default class RichTextSection {
+export default class RichTextSection extends SlackComponent {
   static slackType = 'RichTextSection';
   declare props: Props;
 }

--- a/src/components/rich-text/text.tsx
+++ b/src/components/rich-text/text.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 import {type RichTextStyle} from './types';
 
@@ -17,7 +18,7 @@ export type Props = {
  * <RichTextText style={{ code: true }}>inline code</RichTextText>
  * ```
  */
-export default class RichTextText {
+export default class RichTextText extends SlackComponent {
   static slackType = 'RichTextText';
   declare props: Props;
 }

--- a/src/components/rich-text/user-group.tsx
+++ b/src/components/rich-text/user-group.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   usergroupId: string;
@@ -11,7 +12,7 @@ export type Props = {
  * <RichTextUserGroup usergroupId="S123456" />
  * ```
  */
-export default class RichTextUserGroup {
+export default class RichTextUserGroup extends SlackComponent {
   static slackType = 'RichTextUserGroup';
   declare props: Props;
 }

--- a/src/components/rich-text/user.tsx
+++ b/src/components/rich-text/user.tsx
@@ -1,3 +1,4 @@
+import {SlackComponent} from '../base';
 
 export type Props = {
   userId: string;
@@ -11,7 +12,7 @@ export type Props = {
  * <RichTextUser userId="U123456" />
  * ```
  */
-export default class RichTextUser {
+export default class RichTextUser extends SlackComponent {
   static slackType = 'RichTextUser';
   declare props: Props;
 }

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -70,9 +70,31 @@ export type SerializedElement =
 export type Block = KnownBlock | SlackBlock;
 export type Attachment = MessageAttachment;
 
+export type TextElement = JSX.Element;
+export type ConfirmationElement = JSX.Element;
+export type ImageElement = JSX.Element;
+export type OptionElement = JSX.Element;
+export type OptionGroupElement = JSX.Element;
+export type ButtonElement = JSX.Element;
+export type CheckboxesElement = JSX.Element;
+export type DatePickerElement = JSX.Element;
+export type DateTimePickerElement = JSX.Element;
+export type OverflowElement = JSX.Element;
+export type RadioGroupElement = JSX.Element;
+export type SelectElement = JSX.Element;
+export type TextInputElement = JSX.Element;
+export type TimePickerElement = JSX.Element;
+export type ContextElement = JSX.Element;
+export type RichTextInlineElement = JSX.Element;
+export type RichTextInlineChild = JSX.Element | string;
+export type RichTextBlockElement = JSX.Element;
+export type RichTextBlockChild = JSX.Element | string;
+export type LayoutElement = JSX.Element;
+
 export type InteractiveBlockElement = JSX.Element;
 
 export type InputBlockElement = JSX.Element;
+
 export type BlockElement = JSX.Element;
 
 /**

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,6 +1,14 @@
 type ComponentType = string | ((...parameters: unknown[]) => unknown) | (new (...parameters: unknown[]) => unknown);
 
-export function jsx(type: ComponentType, props: Record<string, unknown>): JSX.Element {
+export type SlackJsxElement<
+  TType extends ComponentType = ComponentType,
+  TProps extends Record<string, unknown> = Record<string, unknown>,
+> = {type: TType; props: TProps; children: unknown[]};
+
+export function jsx<TType extends ComponentType, TProps extends Record<string, unknown>>(
+  type: TType,
+  props: TProps,
+): SlackJsxElement<TType, TProps> {
   const {children} = props;
 
   return {
@@ -10,7 +18,10 @@ export function jsx(type: ComponentType, props: Record<string, unknown>): JSX.El
   };
 }
 
-export function jsxs(type: ComponentType, props: Record<string, unknown>): JSX.Element {
+export function jsxs<TType extends ComponentType, TProps extends Record<string, unknown>>(
+  type: TType,
+  props: TProps,
+): SlackJsxElement<TType, TProps> {
   return jsx(type, props);
 }
 
@@ -18,7 +29,7 @@ export const Fragment = 'fragment';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JSX {
-  export type Element = {type: ComponentType; props: Record<string, unknown>; children: unknown[]};
+  export type Element = SlackJsxElement;
   export type IntrinsicElements = Record<string, Record<string, unknown>>;
   export type ElementClass = {props: Record<string, unknown>};
   export type ElementAttributesProperty = {props: Record<string, unknown>};

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,6 +1,7 @@
 import {type Child, type Block} from '../constants/types';
 import transformers from '../transformers';
 import getType from '../utils/get-type';
+import getTransformerType from '../utils/get-transformer-type';
 import normalizeChildren from '../utils/normalize-children';
 import {pushPath, popPath, report} from '../utils/validation-context';
 
@@ -32,7 +33,18 @@ const parseChildren = (children: Child): ParsedMessage => {
 
   const transformedBlocks: Block[] = [];
   for (const child of normalizedChildren) {
-    const type = getType(child);
+    const type = getTransformerType(child);
+    const component = getType(child);
+    if (!type) {
+      report({
+        message: `No transformer for component type '${component}'.`,
+        rule: 'unsupported-child',
+        subcode: 'unknown-type',
+        component,
+      });
+      continue;
+    }
+
     const transformer = transformers[type];
 
     if (transformer) {
@@ -44,10 +56,10 @@ const parseChildren = (children: Child): ParsedMessage => {
       }
     } else if (type !== 'null') {
       report({
-        message: `No transformer for component type '${type}'.`,
+        message: `No transformer for component type '${component}'.`,
         rule: 'unsupported-child',
         subcode: 'unknown-type',
-        component: type,
+        component,
       });
     }
   }

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -4,7 +4,7 @@ import {
 } from '../constants/types';
 import {type Properties as MessageProperties} from '../components/message';
 import parser from '../parser';
-import getType from '../utils/get-type';
+import getTransformerType from '../utils/get-transformer-type';
 import {warnIfTooMany, warnIfTooLong} from '../utils/validation';
 import {
   initContext, pushPath, popPath, type ValidationMode, type ValidationReporter,
@@ -116,8 +116,7 @@ function render(element: Element, options?: RenderOptions): SlackMessageDraft {
 
   const properties = element.props as MessageProperties;
 
-  const typeName = getType(element);
-  if (typeName !== 'Message') {
+  if (getTransformerType(element) !== 'Message') {
     throw new TypeError('Provided top-level element must be a Message type.');
   }
 

--- a/src/transformers/block/button.tsx
+++ b/src/transformers/block/button.tsx
@@ -1,7 +1,7 @@
 
 import {type Element} from '../../constants/types';
 import {type ButtonProps} from '../../components/block/button';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import Text from '../../components/block/text';
 import {warnIfTooLong, requireField} from '../../utils/validation';
 import {
@@ -59,7 +59,10 @@ const transformButton = (child: Element): ButtonType => {
   }
 
   if (confirm) {
-    res.confirm = transform(confirm) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (accessibilityLabel) {

--- a/src/transformers/block/confirmation.tsx
+++ b/src/transformers/block/confirmation.tsx
@@ -1,6 +1,6 @@
 
 import {type Element} from '../../constants/types';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import {type ConfirmationProps} from '../../components/block/confirmation';
 import Text from '../../components/block/text';
 import {warnIfTooLong, requireField} from '../../utils/validation';
@@ -25,7 +25,7 @@ const transformConfirmation = (child: Element): ConfirmationType => {
   warnIfTooLong('Confirm title', title, MAX_CONFIRM_TITLE);
   warnIfTooLong('Confirm confirm', confirm, MAX_CONFIRM_BUTTON_TEXT);
   warnIfTooLong('Confirm deny', deny, MAX_CONFIRM_BUTTON_TEXT);
-  const text = transform(children ?? <Text plainText>{''}</Text>) as TextType;
+  const text = transformOptional<TextType>(children ?? <Text plainText>{''}</Text>) ?? transform(<Text plainText>{''}</Text>) as TextType;
   warnIfTooLong('Confirm text', text.text, MAX_CONFIRM_TEXT);
 
   const res: ConfirmationType = {

--- a/src/transformers/input/checkboxes.ts
+++ b/src/transformers/input/checkboxes.ts
@@ -1,7 +1,7 @@
 import {type Element} from '../../constants/types';
 import {type Props as CheckboxesProperties} from '../../components/input/checkboxes';
 import {type ConfirmationType} from '../block/confirmation';
-import {transform} from '../transform';
+import {transformElements, transformOptional} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_ACTION_ID_LENGTH, MAX_CHECKBOX_OPTIONS} from '../../constants/limits';
 
@@ -28,17 +28,20 @@ const transformCheckboxes = (child: Element): CheckboxesType => {
   const res: CheckboxesType = {
     type: 'checkboxes',
     action_id: actionId,
-    options: elements.map(element => transform(element as Element)) as OptionType[],
+    options: transformElements<OptionType>(elements as Element[]),
   };
 
   warnIfTooMany('Checkboxes options', res.options, MAX_CHECKBOX_OPTIONS);
 
   if (initialOptions && initialOptions.length > 0) {
-    res.initial_options = initialOptions.map(option => transform(option as Element)) as OptionType[];
+    res.initial_options = transformElements<OptionType>(initialOptions as Element[]);
   }
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (focusOnLoad !== undefined) {

--- a/src/transformers/input/date-picker.tsx
+++ b/src/transformers/input/date-picker.tsx
@@ -3,7 +3,7 @@ import {type Props as DatePickerProperties} from '../../components/input/date-pi
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';
 import {type ConfirmationType} from '../block/confirmation';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import Text from '../../components/block/text';
 import {warnIfTooLong, requireField} from '../../utils/validation';
 import {report} from '../../utils/validation-context';
@@ -70,7 +70,10 @@ const transformDatePicker = (child: Element): DatePickerType => {
   }
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (focusOnLoad !== undefined) {

--- a/src/transformers/input/date-time-picker.ts
+++ b/src/transformers/input/date-time-picker.ts
@@ -1,7 +1,7 @@
 import {type Element} from '../../constants/types';
 import {type Props as DateTimePickerProperties} from '../../components/input/date-time-picker';
 import {type ConfirmationType} from '../block/confirmation';
-import {transform} from '../transform';
+import {transformOptional} from '../transform';
 import {warnIfTooLong, requireField} from '../../utils/validation';
 import {MAX_ACTION_ID_LENGTH} from '../../constants/limits';
 
@@ -33,7 +33,10 @@ const transformDateTimePicker = (child: Element): DateTimePickerType => {
   }
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (focusOnLoad !== undefined) {

--- a/src/transformers/input/option-group.tsx
+++ b/src/transformers/input/option-group.tsx
@@ -3,7 +3,7 @@ import Text from '../../components/block/text';
 import {type Props as OptionGroupProperties} from '../../components/input/option-group';
 import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';
-import {transform} from '../transform';
+import {transform, transformElements} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_OPTION_GROUP_LABEL, MAX_OPTION_GROUP_OPTIONS} from '../../constants/limits';
 
@@ -26,7 +26,7 @@ const transformOptionGroup = (child: Element): OptionGroupType => {
 
   return {
     label: transform(<Text plainText>{label ?? ''}</Text>) as TextType,
-    options: options.map(option => transform(option as Element)) as OptionType[],
+    options: transformElements<OptionType>(options as Element[]),
   };
 };
 

--- a/src/transformers/input/overflow.ts
+++ b/src/transformers/input/overflow.ts
@@ -1,7 +1,7 @@
 import {type Element} from '../../constants/types';
 import {type Props as OverflowProperties} from '../../components/input/overflow';
 import {type ConfirmationType} from '../block/confirmation';
-import {transform} from '../transform';
+import {transformElements, transformOptional} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_ACTION_ID_LENGTH, MAX_OVERFLOW_OPTIONS} from '../../constants/limits';
 
@@ -25,13 +25,16 @@ const transformOverflow = (child: Element): OverflowType => {
   const res: OverflowType = {
     type: 'overflow',
     action_id: actionId,
-    options: elements.map(element => transform(element as Element)) as OptionType[],
+    options: transformElements<OptionType>(elements as Element[]),
   };
 
   warnIfTooMany('Overflow options', res.options, MAX_OVERFLOW_OPTIONS);
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   return res;

--- a/src/transformers/input/radio-group.ts
+++ b/src/transformers/input/radio-group.ts
@@ -1,7 +1,7 @@
 import {type Element} from '../../constants/types';
 import {type Props as RadioGroupProperties} from '../../components/input/radio-group';
 import {type ConfirmationType} from '../block/confirmation';
-import {transform} from '../transform';
+import {transformElements, transformOptional} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_ACTION_ID_LENGTH, MAX_RADIO_OPTIONS} from '../../constants/limits';
 
@@ -28,17 +28,23 @@ const transformRadioGroup = (child: Element): RadioGroupType => {
   const res: RadioGroupType = {
     type: 'radio_buttons',
     action_id: actionId,
-    options: elements.map(element => transform(element as Element)) as OptionType[],
+    options: transformElements<OptionType>(elements as Element[]),
   };
 
   warnIfTooMany('RadioGroup options', res.options, MAX_RADIO_OPTIONS);
 
   if (initialOption) {
-    res.initial_option = transform(initialOption as Element) as OptionType;
+    const transformedOption = transformOptional<OptionType>(initialOption as Element);
+    if (transformedOption) {
+      res.initial_option = transformedOption;
+    }
   }
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (focusOnLoad !== undefined) {

--- a/src/transformers/input/select.tsx
+++ b/src/transformers/input/select.tsx
@@ -4,8 +4,8 @@ import {type TextType} from '../block/text';
 import {type ConfirmationType} from '../block/confirmation';
 import {type Props as SelectProperties, selectTypes} from '../../components/input/select';
 import Text from '../../components/block/text';
-import {transform} from '../transform';
-import getType from '../../utils/get-type';
+import {transform, transformElements, transformOptional} from '../transform';
+import getTransformerType from '../../utils/get-transformer-type';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {
   MAX_ACTION_ID_LENGTH,
@@ -79,11 +79,11 @@ const normalizeElements = (elements?: SelectProperties['children']): JSX.Element
 };
 
 const assignStaticOptions = (elements: JSX.Element[], result: SelectType): void => {
-  const elementType = getType(elements[0] as Element);
-  if (elements.some(element => getType(element as Element) !== elementType)) {
-    if (elementType === OPTION && elements.some(element => getType(element as Element) !== OPTION_GROUP)) {
+  const elementType = getTransformerType(elements[0] as Element);
+  if (elements.some(element => getTransformerType(element as Element) !== elementType)) {
+    if (elementType === OPTION && elements.some(element => getTransformerType(element as Element) !== OPTION_GROUP)) {
       throw new TypeError('You cannot mix OptionGroup types with Option types in a Select block.');
-    } else if (elementType === OPTION_GROUP && elements.some(element => getType(element as Element) !== OPTION)) {
+    } else if (elementType === OPTION_GROUP && elements.some(element => getTransformerType(element as Element) !== OPTION)) {
       throw new TypeError('You cannot mix OptionGroup types with Option types in a Select block.');
     }
 
@@ -91,9 +91,9 @@ const assignStaticOptions = (elements: JSX.Element[], result: SelectType): void 
   }
 
   if (elementType === OPTION) {
-    result.options = elements.map(element => transform(element as Element)) as OptionType[];
+    result.options = transformElements<OptionType>(elements as Element[]);
   } else if (elementType === OPTION_GROUP) {
-    result.option_groups = elements.map(element => transform(element as Element)) as OptionGroupType[];
+    result.option_groups = transformElements<OptionGroupType>(elements as Element[]);
   }
 };
 
@@ -187,7 +187,7 @@ const applyInitialSelections = (
     case selectTypes.STATIC:
     case selectTypes.EXTERNAL: {
       if (initialOptions && initialOptions.length > 0) {
-        const transformedOptions = initialOptions.map(element => transform(element as Element)) as OptionType[];
+        const transformedOptions = transformElements<OptionType>(initialOptions as Element[]);
 
         if (isMulti) {
           result.initial_options = transformedOptions;
@@ -236,17 +236,28 @@ const transformSelect = (child: Element): SelectType => {
   };
 
   const elements = normalizeElements(children);
+  const knownElements = elements.filter(element => {
+    if (getTransformerType(element as Element)) {
+      return true;
+    }
+
+    transformOptional(element as Element);
+    return false;
+  });
 
   if (type === selectTypes.STATIC) {
     requireField('options', elements);
 
-    if (elements.length > 0) {
-      assignStaticOptions(elements, result);
+    if (knownElements.length > 0) {
+      assignStaticOptions(knownElements, result);
     }
   }
 
   if (confirm) {
-    result.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      result.confirm = transformedConfirm;
+    }
   }
 
   applyInitialSelections(type, Boolean(multi), result, {

--- a/src/transformers/input/time-picker.tsx
+++ b/src/transformers/input/time-picker.tsx
@@ -3,7 +3,7 @@ import {type Element} from '../../constants/types';
 import {type TextType} from '../block/text';
 import {type ConfirmationType} from '../block/confirmation';
 import {type Props as TimePickerProperties} from '../../components/input/time-picker';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import Text from '../../components/block/text';
 import {warnIfTooLong, requireField} from '../../utils/validation';
 import {report} from '../../utils/validation-context';
@@ -62,7 +62,10 @@ const transformTimePicker = (child: Element): TimePickerType => {
   }
 
   if (confirm) {
-    res.confirm = transform(confirm as Element) as ConfirmationType;
+    const transformedConfirm = transformOptional<ConfirmationType>(confirm as Element);
+    if (transformedConfirm) {
+      res.confirm = transformedConfirm;
+    }
   }
 
   if (focusOnLoad !== undefined) {

--- a/src/transformers/layout/actions.ts
+++ b/src/transformers/layout/actions.ts
@@ -1,6 +1,6 @@
 import {type Element, type SerializedInteractiveBlockElement, type InteractiveBlockElement} from '../../constants/types';
 import {type Props as ActionProperties} from '../../components/layout/actions';
-import {transform} from '../transform';
+import {transformElements} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_BLOCK_ID_LENGTH, MAX_ACTIONS_ELEMENTS} from '../../constants/limits';
 
@@ -20,7 +20,7 @@ const transformActions = (child: Element): ActionType => {
 
   const res: ActionType = {
     type: 'actions',
-    elements: elements.map(element => transform(element as Element) as SerializedInteractiveBlockElement),
+    elements: transformElements<SerializedInteractiveBlockElement>(elements as Element[]),
   };
 
   if (blockId) {

--- a/src/transformers/layout/container.ts
+++ b/src/transformers/layout/container.ts
@@ -1,6 +1,6 @@
 import {type Props as ContainerProperties} from '../../components/layout/container';
 import {type Element, type Child} from '../../constants/types';
-import {transform} from '../transform';
+import {transformElements} from '../transform';
 import normalizeChildren from '../../utils/normalize-children';
 
 type ContainerType = Child[];
@@ -9,7 +9,7 @@ const transformContainer = (child: Element): ContainerType => {
   const {children} = child.props as ContainerProperties;
   const elements = normalizeChildren(children);
 
-  return (elements as Element[]).map(element => transform(element)) as Child[];
+  return transformElements<Child>(elements as Element[]);
 };
 
 export default transformContainer;

--- a/src/transformers/layout/context.ts
+++ b/src/transformers/layout/context.ts
@@ -2,7 +2,7 @@ import {type Element} from '../../constants/types';
 import {type Props as ContextProperties, type ImageOrText as ImageOrTextElement} from '../../components/layout/context';
 import {type TextType} from '../block/text';
 import {type ImageType} from '../block/image';
-import {transform} from '../transform';
+import {transformElements} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireField} from '../../utils/validation';
 import {MAX_BLOCK_ID_LENGTH, MAX_CONTEXT_ELEMENTS} from '../../constants/limits';
 
@@ -24,7 +24,7 @@ const transformContext = (child: Element): ContextType => {
 
   const res: ContextType = {
     type: 'context',
-    elements: elements.map(element => transform(element as Element)) as ImageOrText[],
+    elements: transformElements<ImageOrText>(elements as Element[]),
   };
 
   if (blockId) {

--- a/src/transformers/layout/input.tsx
+++ b/src/transformers/layout/input.tsx
@@ -2,7 +2,7 @@
 import {type Element, type SerializedInputBlockElement} from '../../constants/types';
 import {type TextType} from '../block/text';
 import {type Props as InputProperties} from '../../components/layout/input';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import Text from '../../components/block/text';
 import {warnIfTooLong, requireField} from '../../utils/validation';
 import {MAX_BLOCK_ID_LENGTH, MAX_INPUT_HINT, MAX_INPUT_LABEL} from '../../constants/limits';
@@ -19,7 +19,7 @@ export type InputType = {
 const transformInput = (child: Element): InputType => {
   const {label, element, hint, optional, blockId} = child.props as InputProperties;
   const resolvedElement: SerializedInputBlockElement = element
-    ? transform(element as Element) as SerializedInputBlockElement
+    ? transformOptional<SerializedInputBlockElement>(element as Element) ?? {type: 'plain_text_input', action_id: ''}
     : {type: 'plain_text_input', action_id: ''};
 
   requireField('label', label);

--- a/src/transformers/layout/section.ts
+++ b/src/transformers/layout/section.ts
@@ -1,7 +1,7 @@
 import {type Element, type SerializedBlockElement} from '../../constants/types';
 import {type Props as SectionComponentProps} from '../../components/layout/section';
 import {type TextType as Text} from '../block/text';
-import {transform} from '../transform';
+import {transform, transformOptional} from '../transform';
 import {warnIfTooLong, warnIfTooMany, requireOneOf} from '../../utils/validation';
 import {MAX_BLOCK_ID_LENGTH, MAX_SECTION_FIELD_TEXT, MAX_SECTION_FIELDS} from '../../constants/limits';
 import TextComponent from '../../components/block/text';
@@ -64,7 +64,10 @@ const transformSection = (element: Element): SectionType => {
   }
 
   if (accessory) {
-    res.accessory = transform(accessory) as SerializedBlockElement;
+    const transformedAccessory = transformOptional<SerializedBlockElement>(accessory);
+    if (transformedAccessory) {
+      res.accessory = transformedAccessory;
+    }
   }
 
   if (expand !== undefined) {
@@ -75,9 +78,11 @@ const transformSection = (element: Element): SectionType => {
     res.fields = [];
     for (const field of normalizedFields) {
       if (field) {
-        const t = transform(toTextElement(field)) as Text;
-        warnIfTooLong('Section field text', t.text, MAX_SECTION_FIELD_TEXT);
-        res.fields.push(t);
+        const transformedField = transformOptional<Text>(toTextElement(field));
+        if (transformedField) {
+          warnIfTooLong('Section field text', transformedField.text, MAX_SECTION_FIELD_TEXT);
+          res.fields.push(transformedField);
+        }
       }
     }
 

--- a/src/transformers/rich-text/utils.ts
+++ b/src/transformers/rich-text/utils.ts
@@ -1,5 +1,5 @@
 import {type Element} from '../../constants/types';
-import {transform} from '../transform';
+import {transformOptional} from '../transform';
 
 type RichTextChild = Element | string;
 
@@ -27,27 +27,41 @@ const normalizeRichTextChildren = (children: unknown): RichTextChild[] => {
 
 export const toInlineElements = (children: unknown): Array<Record<string, unknown>> => {
   const items = normalizeRichTextChildren(children);
+  const elements: Array<Record<string, unknown>> = [];
 
-  return items.map(item => {
+  for (const item of items) {
     if (typeof item === 'string') {
-      return {type: 'text', text: item};
+      elements.push({type: 'text', text: item});
+      continue;
     }
 
-    return transform(item) as Record<string, unknown>;
-  });
+    const transformed = transformOptional<Record<string, unknown>>(item);
+    if (transformed) {
+      elements.push(transformed);
+    }
+  }
+
+  return elements;
 };
 
 export const toBlockElements = (children: unknown): Array<Record<string, unknown>> => {
   const items = normalizeRichTextChildren(children);
+  const elements: Array<Record<string, unknown>> = [];
 
-  return items.map(item => {
+  for (const item of items) {
     if (typeof item === 'string') {
-      return {
+      elements.push({
         type: 'rich_text_section',
         elements: [{type: 'text', text: item}],
-      };
+      });
+      continue;
     }
 
-    return transform(item) as Record<string, unknown>;
-  });
+    const transformed = transformOptional<Record<string, unknown>>(item);
+    if (transformed) {
+      elements.push(transformed);
+    }
+  }
+
+  return elements;
 };

--- a/src/transformers/transform.ts
+++ b/src/transformers/transform.ts
@@ -1,20 +1,22 @@
 import {type Element} from '../constants/types';
 import getType from '../utils/get-type';
+import getTransformerType from '../utils/get-transformer-type';
 import {pushPath, popPath, report} from '../utils/validation-context';
 
 import Transformers from './registry';
 
 export const transform = (element: Element): unknown => {
-  const type = getType(element);
+  const type = getTransformerType(element);
+  const component = getType(element);
 
-  if (!Transformers[type]) {
+  if (!type || !Transformers[type]) {
     report({
-      message: `No transformer for component type '${type}'.`,
+      message: `No transformer for component type '${component}'.`,
       rule: 'unsupported-child',
       subcode: 'unknown-type',
-      component: type,
+      component,
     });
-    return {};
+    return undefined;
   }
 
   pushPath(type);
@@ -23,4 +25,18 @@ export const transform = (element: Element): unknown => {
   } finally {
     popPath();
   }
+};
+
+export const transformElements = <T>(elements: readonly Element[]): T[] =>
+  elements.flatMap(element => {
+    const transformed = transform(element);
+    return transformed === undefined ? [] : [transformed as T];
+  });
+
+export const transformOptional = <T>(element?: Element): T | undefined => {
+  if (!element) {
+    return undefined;
+  }
+
+  return transform(element) as T | undefined;
 };

--- a/src/utils/get-transformer-type.ts
+++ b/src/utils/get-transformer-type.ts
@@ -1,0 +1,30 @@
+import {type Child} from '../constants/types';
+import {isSlackComponentType} from '../components/base';
+
+const getTransformerType = (element: Child): string | undefined => {
+  if (typeof element === 'string') {
+    return 'string';
+  }
+
+  if (element === null || element === undefined || typeof element === 'boolean') {
+    return 'null';
+  }
+
+  if (Array.isArray(element)) {
+    throw new TypeError('Cannot type arrays');
+  }
+
+  const {type} = element;
+
+  if (typeof type === 'string') {
+    return type;
+  }
+
+  if (isSlackComponentType(type)) {
+    return type.slackType;
+  }
+
+  return undefined;
+};
+
+export default getTransformerType;

--- a/test/branding/branding.test.tsx
+++ b/test/branding/branding.test.tsx
@@ -1,0 +1,51 @@
+import {expect, test, vi} from 'vitest';
+
+import render from '../../src';
+import SlackMessage from '../../src/components/message';
+import Section from '../../src/components/layout/section';
+import SlackText from '../../src/components/block/text';
+
+function Message() {
+  return null as unknown as JSX.Element;
+}
+
+function Text() {
+  return null as unknown as JSX.Element;
+}
+
+Object.assign(Message, {slackType: 'Message'});
+Object.assign(Text, {slackType: 'Text'});
+
+test('rejects an unbranded top-level Message lookalike', () => {
+  expect(() => render(<Message/> as never)).toThrow('Provided top-level element must be a Message type.');
+});
+
+test('ignores an unbranded nested Text lookalike even when the name matches', () => {
+  const onValidation = vi.fn();
+
+  const result = render(
+    <SlackMessage>
+      <Section
+        text={<SlackText>Visible</SlackText>}
+        fields={<Text/> as never}
+      />
+    </SlackMessage>,
+    {validate: 'warn', onValidation},
+  );
+
+  expect(result.blocks).toEqual([
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'Visible',
+      },
+    },
+  ]);
+
+  expect(onValidation).toHaveBeenCalledWith(expect.objectContaining({
+    rule: 'unsupported-child',
+    subcode: 'unknown-type',
+    component: 'Text',
+  }));
+});

--- a/test/parser/parser.test.tsx
+++ b/test/parser/parser.test.tsx
@@ -6,6 +6,7 @@ import {
   vi,
 } from 'vitest';
 
+import {SlackComponent} from '../../src/components/base';
 import {initContext} from '../../src/utils/validation-context';
 import {SlackblockValidationError} from '../../src/errors';
 import parser from '../../src/parser';
@@ -40,8 +41,9 @@ test('it returns a basic message if the child is just a string', () => {
   expect(result).toEqual(expected);
 });
 
-function Foo() {
-  return <p>Test</p>;
+class Foo extends SlackComponent {
+  static slackType = 'Foo';
+  declare props: Record<string, unknown>;
 }
 
 test('it passes the item to the right transformer', () => {


### PR DESCRIPTION
## Summary
- add an internal component brand so parser/renderer routing only accepts slackblock-owned components
- ignore unbranded lookalike components consistently, including nested children in transformers and rich text utilities
- add regression coverage for branded routing and unknown child handling

## Verification
- pnpm test:tsc
- pnpm test:unit
- pnpm run test:lint